### PR TITLE
feat: persist sessions with refresh tokens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,7 +15,7 @@ import ErrorBoundary from "./components/system/ErrorBoundary";
 
 // App.tsx
 function AppContent() {
-  const { setUserToken } = useAuth();
+  const { setSession, updateLastActive } = useAuth();
   useMobileSetup();
 
   const {
@@ -77,7 +77,7 @@ function AppContent() {
           selectedExerciseForSetup={selectedExerciseForSetup}
           setSelectedExerciseForSetup={setSelectedExerciseForSetup}
           isAuthenticated={isAuthenticated}
-          onAuthSuccess={(token) => handleAuthSuccess(token, setUserToken)}
+          onAuthSuccess={(session) => handleAuthSuccess(session, setSession, updateLastActive)}
           onNavigateToSignUp={navigateToSignUp}
           onNavigateToSignIn={navigateToSignIn}
           onCreateRoutine={showCreateRoutine}

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -22,7 +22,7 @@ interface AppRouterProps {
   setSelectedExerciseForSetup: (exercise: Exercise | null) => void;
 
   isAuthenticated: boolean;
-  onAuthSuccess: (token: string) => void;
+  onAuthSuccess: (session: { access_token: string; refresh_token: string }) => void;
   onNavigateToSignUp: () => void;
   onNavigateToSignIn: () => void;
 

--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -10,7 +10,7 @@ import { toast } from "sonner";
 import { AppScreen, Stack, Spacer } from "../layouts";
 
 interface SignInScreenProps {
-  onAuthSuccess: (token: string) => void;
+  onAuthSuccess: (session: { access_token: string; refresh_token: string }) => void;
   onNavigateToSignUp: () => void;
   bottomBar?: React.ReactNode;
 }
@@ -29,9 +29,8 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
     }
     setIsLoading(true);
     try {
-      const token = await supabaseAPI.signIn(email, password);
-      supabaseAPI.setToken(token);
-      onAuthSuccess(token);
+      const session = await supabaseAPI.signIn(email, password);
+      onAuthSuccess(session);
       toast.success("Welcome back!");
     } catch (error) {
       console.error("Sign in failed:", error);

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -30,8 +30,13 @@ export function useAppNavigation() {
     return false;
   };
 
-  const handleAuthSuccess = (token: string, setUserToken: (token: string) => void) => {
-    setUserToken(token);
+  const handleAuthSuccess = (
+    session: { access_token: string; refresh_token: string },
+    setSession: (accessToken: string, refreshToken: string) => void,
+    updateLastActive: () => void
+  ) => {
+    setSession(session.access_token, session.refresh_token);
+    updateLastActive();
     setCurrentView("workouts");
     setActiveTab("workouts");
   };

--- a/test/utils/auth-helpers.ts
+++ b/test/utils/auth-helpers.ts
@@ -155,18 +155,18 @@ export function waitForAuthStateChange(
  * Validate sign up result
  */
 export function validateSignUpResult(result: any): boolean {
-  return result && 
-         typeof result === 'object' && 
-         (result.success === true || result.user || result.id);
+  return result &&
+         typeof result === 'object' &&
+         ((result.access_token && result.refresh_token) || result.success === true || result.user || result.id);
 }
 
 /**
  * Validate sign in result
  */
 export function validateSignInResult(result: any): boolean {
-  return result && 
-         typeof result === 'object' && 
-         (result.success === true || result.user || result.token);
+  return result &&
+         typeof result === 'object' &&
+         ((result.access_token && result.refresh_token) || result.success === true || result.user || result.token);
 }
 
 /**

--- a/utils/supabase/supabase-base.ts
+++ b/utils/supabase/supabase-base.ts
@@ -62,6 +62,9 @@ export class SupabaseBase {
     return headers;
   }
 
+  // Hook for subclasses to update last-active timestamp. No-op by default.
+  protected async touchLastActive(): Promise<void> {}
+
   protected async fetchJson<T>(
     url: string,
     includeAuth = true,
@@ -92,6 +95,15 @@ export class SupabaseBase {
     } catch {
       // In rare cases Supabase might return plain text; pass it through
       return text as unknown as T;
+    }
+    finally {
+      if (includeAuth && this.userToken) {
+        try {
+          await this.touchLastActive();
+        } catch (e) {
+          console.warn("Failed to update last_active_at", e);
+        }
+      }
     }
   }
 

--- a/utils/supabase/supabase-types.ts
+++ b/utils/supabase/supabase-types.ts
@@ -45,6 +45,7 @@ export interface Exercise {
     display_name: string;
     height_cm?: number;
     weight_kg?: number;
+    last_active_at?: string;
   }
   
   export interface AuthUser {


### PR DESCRIPTION
## Summary
- store refresh token and last activity in auth context
- refresh sessions and auto sign-out after 6 months inactivity
- update Supabase utilities to support refresh tokens and last_active tracking

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d3c153c083219d2255f3ef06481b