### PR TITLE
Skip creating exercises without set payloads

### DIFF
--- a/components/routine-editor/collapseJournal.ts
+++ b/components/routine-editor/collapseJournal.ts
@@ -243,6 +243,21 @@ export function collapseJournal(journal: EditJournal): SavePlan {
     }
   }
 
+  // Remove exercises without any set payloads
+  for (const [exIdStr, sets] of Object.entries(plan.createSetsByExercise)) {
+    if (!sets.length) {
+      delete plan.createSetsByExercise[exIdStr as unknown as Id];
+    }
+  }
+  plan.createExercises = plan.createExercises.filter((e) => {
+    const sets = plan.createSetsByExercise[e.tempExId];
+    if (!sets || sets.length === 0) {
+      delete plan.createSetsByExercise[e.tempExId];
+      return false;
+    }
+    return true;
+  });
+
   // Optional: re-index set_order to be contiguous per exercise here,
   // if your backend does not do this as part of an RPC/transaction.
 

--- a/components/routine-editor/journalRunner.ts
+++ b/components/routine-editor/journalRunner.ts
@@ -49,6 +49,11 @@ export async function runJournal(plan: SavePlan, routineId: number, exMap: ExIdM
   DGB(`Creating ${plan.createExercises.length} new exercises:`, plan.createExercises);
   const createdTemplateIds = new Map<Id, number>(); // temp exId -> templateId
   for (const e of plan.createExercises) {
+    const sets = plan.createSetsByExercise[e.tempExId];
+    if (!sets || sets.length === 0) {
+      DGB(`Skipping exercise ${e.tempExId} - no set payloads`);
+      continue;
+    }
     DGB(`Creating exercise:`, e);
     const saved = await supabaseAPI.addExerciseToRoutine(routineId, e.exerciseId, e.order);
     if (saved) {

--- a/test/collapseJournal.test.ts
+++ b/test/collapseJournal.test.ts
@@ -1,0 +1,17 @@
+import { collapseJournal } from '../components/routine-editor/collapseJournal';
+import type { EditJournal } from '../components/routine-editor/journalTypes';
+
+test('skip creating exercise when all sets are empty', () => {
+  const journal: EditJournal = {
+    ex: [
+      { t: 'EX_ADD', exId: -1, exerciseId: 1, name: 'Test', order: 1 },
+    ],
+    sets: [
+      { t: 'SET_ADD', exId: -1, setId: -1, reps: '0', weight: '0', set_order: 1 },
+    ],
+  };
+
+  const plan = collapseJournal(journal);
+  expect(plan.createExercises).toHaveLength(0);
+  expect(Object.keys(plan.createSetsByExercise)).toHaveLength(0);
+});

--- a/test/journalRunner.test.ts
+++ b/test/journalRunner.test.ts
@@ -1,0 +1,34 @@
+jest.mock('../utils/supabase/supabase-api', () => ({
+  supabaseAPI: {
+    deleteRoutineExercise: jest.fn().mockResolvedValue(undefined),
+    deleteExerciseSet: jest.fn().mockResolvedValue(undefined),
+    updateExerciseSet: jest.fn().mockResolvedValue(undefined),
+    updateExerciseSetOrder: jest.fn().mockResolvedValue(undefined),
+    addExerciseToRoutine: jest.fn().mockResolvedValue(undefined),
+    addExerciseSetsToRoutine: jest.fn().mockResolvedValue(undefined),
+    recomputeAndSaveRoutineMuscleSummary: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { runJournal } from '../components/routine-editor/journalRunner';
+import type { SavePlan } from '../components/routine-editor/collapseJournal';
+import type { ExIdMap } from '../components/routine-editor/journalRunner';
+import { supabaseAPI } from '../utils/supabase/supabase-api';
+
+test('runJournal skips creating exercises without set payloads', async () => {
+  const plan: SavePlan = {
+    deleteExercises: [],
+    deleteSets: [],
+    updateSets: [],
+    orderSets: [],
+    createExercises: [
+      { tempExId: -1, exerciseId: 1, order: 1, name: 'Test' },
+    ],
+    createSetsByExercise: {},
+  };
+  const exMap: ExIdMap = { [-1]: { exerciseId: 1 } };
+
+  await runJournal(plan, 1, exMap);
+
+  expect(supabaseAPI.addExerciseToRoutine).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- prune createExercises entries lacking set payloads
- guard runJournal from creating exercises without sets
- add tests for empty-set exercise cases

## Testing
- `npm test test/collapseJournal.test.ts test/journalRunner.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b6f73c09b883218d20ca165f42d040