### PR TITLE
refactor: replace hardcoded white with theme tokens

### DIFF
--- a/components/TactileButton.tsx
+++ b/components/TactileButton.tsx
@@ -18,11 +18,11 @@ export function TactileButton({
   const baseClasses = "btn-tactile rounded-xl border-0 font-medium";
   
   const variantClasses = {
-    primary: "bg-warm-coral hover:bg-warm-coral/90 text-white",
+    primary: "bg-primary hover:bg-primary-hover text-primary-foreground",
     secondary: "bg-warm-cream hover:bg-warm-cream/90 text-warm-brown",
-    sage: "bg-warm-sage hover:bg-warm-sage/90 text-white btn-tactile-sage",
+    sage: "bg-warm-sage hover:bg-warm-sage/90 text-primary-foreground btn-tactile-sage",
     peach: "bg-warm-peach hover:bg-warm-peach/90 text-warm-brown",
-    mint: "bg-warm-mint hover:bg-warm-mint/90 text-white"
+    mint: "bg-warm-mint hover:bg-warm-mint/90 text-primary-foreground"
   };
 
   const sizeClasses = {

--- a/components/layouts/AppScreen.md
+++ b/components/layouts/AppScreen.md
@@ -481,7 +481,7 @@ Exact pixel control for specific use cases.
 **Before:**
 ```tsx
 <div className="min-h-[100dvh] bg-background flex flex-col pt-safe">
-  <div className="relative flex items-center p-4 bg-white/80 backdrop-blur-sm border-b border-[var(--border)]">
+  <div className="relative flex items-center p-4 bg-card/80 backdrop-blur-sm border-b border-[var(--border)]">
     <h1>Screen Title</h1>
   </div>
   <div className="px-4 py-4 space-y-3">

--- a/components/layouts/AppScreen.tsx
+++ b/components/layouts/AppScreen.tsx
@@ -133,7 +133,7 @@ export default function AppScreen({
       className={cx(
         "shrink-0",
         stickyHeader && "sticky top-0 z-30",
-        "bg-white/80 backdrop-blur-sm",
+        "bg-card/80 backdrop-blur-sm",
         showHeaderBorder && "border-b border-border",
         headerShellClassName
       )}
@@ -195,7 +195,7 @@ export default function AppScreen({
           className={cx(
             "shrink-0",
             bottomBarSticky && "sticky bottom-0 z-30",
-            "bg-white/95 backdrop-blur-sm",
+            "bg-card/95 backdrop-blur-sm",
             showBottomBarBorder && "border-t border-border",
             bottomBarShellClassName
           )}

--- a/components/layouts/FooterBar.tsx
+++ b/components/layouts/FooterBar.tsx
@@ -49,10 +49,10 @@ const sizeMap = {
 
 const bgMap: Record<Bg, string> = {
   solid:
-    "bg-white border-t border-border shadow-[0_-2px_8px_rgba(0,0,0,0.04)]",
+    "bg-card border-t border-border shadow-[0_-2px_8px_rgba(0,0,0,0.04)]",
   translucent:
-    "bg-white/95 backdrop-blur-sm border-t border-border shadow-[0_-2px_8px_rgba(0,0,0,0.04)]",
-  elevated: "bg-white shadow-lg border-t border-border",
+    "bg-card/95 backdrop-blur-sm border-t border-border shadow-[0_-2px_8px_rgba(0,0,0,0.04)]",
+  elevated: "bg-card shadow-lg border-t border-border",
 };
 
 const alignMap: Record<Align, string> = {

--- a/components/layouts/ScreenHeader.tsx
+++ b/components/layouts/ScreenHeader.tsx
@@ -49,7 +49,7 @@ export default function ScreenHeader({
 
   const containerClasses = [
     sticky ? "sticky top-0 z-30" : "",
-    "relative w-full bg-white/80 backdrop-blur-sm",
+    "relative w-full bg-card/80 backdrop-blur-sm",
     padSafeArea && "pt-safe",
     showBorder ? "border-b border-border" : "",
     className,

--- a/components/layouts/Section.md
+++ b/components/layouts/Section.md
@@ -762,7 +762,7 @@ The component uses these CSS custom properties for theming:
 
 ```tsx
 // Before - Manual styling
-<div className="bg-white rounded-2xl shadow-sm p-4 border-b border-gray-200">
+<div className="bg-card rounded-2xl shadow-sm p-4 border-b border-gray-200">
   <h2 className="text-lg font-medium text-gray-900 mb-3">Title</h2>
   <div className="text-gray-600">Content</div>
 </div>

--- a/components/layouts/Section.tsx
+++ b/components/layouts/Section.tsx
@@ -56,9 +56,9 @@ const shadowMap: Record<Shadow, string> = {
 };
 const bgMap: Record<Bg, string> = {
   transparent: "bg-transparent",
-  card: "bg-white",
+  card: "bg-card",
   muted: "bg-soft-gray/30",
-  translucent: "bg-white/80 backdrop-blur-sm",
+  translucent: "bg-card/80 backdrop-blur-sm",
 };
 const dividerMap: Record<Divider, string> = {
   none: "",
@@ -70,9 +70,9 @@ const dividerMap: Record<Divider, string> = {
 /** Variant presets (props that follow still take precedence) */
 const variantClass: Record<Variant, string> = {
   plain: "bg-transparent shadow-none rounded-none",
-  card: "bg-white shadow-sm rounded-2xl",
-  panel: "bg-white shadow-md rounded-2xl border border-border",
-  translucent: "bg-white/80 backdrop-blur-sm shadow-sm rounded-2xl",
+  card: "bg-card shadow-sm rounded-2xl",
+  panel: "bg-card shadow-md rounded-2xl border border-border",
+  translucent: "bg-card/80 backdrop-blur-sm shadow-sm rounded-2xl",
   muted: "bg-soft-gray/30 rounded-2xl shadow-none",
 };
 
@@ -158,7 +158,7 @@ export default function Section<T extends keyof JSX.IntrinsicElements = "section
 
       {/* Loading overlay */}
       {loading && loadingBehavior === "overlay" && (
-        <div className="absolute inset-0 rounded-inherit bg-white/60 backdrop-blur-[2px] grid place-items-center pointer-events-none">
+        <div className="absolute inset-0 rounded-inherit bg-card/60 backdrop-blur-[2px] grid place-items-center pointer-events-none">
           <div className="flex items-center gap-2 text-warm-brown/70">
             <div className="animate-spin w-5 h-5 border-2 border-warm-coral border-t-transparent rounded-full" />
             <span className="text-sm">Loading…</span>

--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -72,7 +72,7 @@ const ExerciseRow = memo(function ExerciseRow({
           selected
             // toned down selection (less “bright orange”)
             ? "bg-warm-coral/60 border-warm-coral/30 shadow-md"
-            : "bg-white border-border hover:bg-soft-gray/50 hover:border-warm-coral/30 hover:shadow-md",
+            : "bg-card border-border hover:bg-soft-gray/50 hover:border-warm-coral/30 hover:shadow-md",
         ].join(" ")}
       >
         <div className="flex items-center gap-3 md:gap-4">
@@ -292,7 +292,7 @@ export function AddExercisesToRoutineScreen({
             disabled={selectedExercises.length === 0 || isAddingExercise}
             className={`h-12 md:h-14 sm:w-auto px-6 md:px-8 font-medium border-0 transition-all ${
               selectedExercises.length > 0
-                ? "bg-warm-coral hover:bg-warm-coral/90 text-white/90 btn-tactile"
+                ? "bg-primary hover:bg-primary-hover text-primary-foreground opacity-90 btn-tactile"
                 : "bg-warm-brown/20 text-warm-brown/40 cursor-not-allowed"
             }`}
           >

--- a/components/screens/CreateRoutineScreen.tsx
+++ b/components/screens/CreateRoutineScreen.tsx
@@ -89,7 +89,7 @@ export default function CreateRoutineScreen({
           <TactileButton
             onClick={handleCreateRoutine}
             disabled={!routineName.trim() || isCreating}
-            className="w-full h-12 md:h-14 bg-warm-coral hover:bg-warm-coral/90 text-white font-medium text-sm md:text-base rounded-full disabled:opacity-50 disabled:cursor-not-allowed border-0"
+            className="w-full h-12 md:h-14 bg-primary hover:bg-primary-hover text-primary-foreground font-medium text-sm md:text-base rounded-full disabled:opacity-50 disabled:cursor-not-allowed border-0"
           >
             <div className="flex items-center justify-center gap-2">
               <Plus size={20} />

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -535,7 +535,7 @@ export function ExerciseSetupScreen({
             className={`flex-1 h-11 md:h-12 font-medium border-0 transition-all ${
               access === RoutineAccess.ReadOnly
                 ? "opacity-50 cursor-not-allowed bg-gray-400"
-                : "bg-warm-coral hover:bg-warm-coral/90 text-white btn-tactile"
+                : "bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
             }`}
           >
             {savingAll ? "SAVING..." : `SAVE ALL`}
@@ -587,7 +587,7 @@ export function ExerciseSetupScreen({
               </span>
             </div>
           }
-          className="bg-white/80 border-border"
+          className="bg-card/80 border-border"
           bodyClassName="pt-2"
         >
           {isLoading || !ex.loaded ? (
@@ -631,7 +631,7 @@ export function ExerciseSetupScreen({
       return (
         <div className="space-y-3">
           {[1, 2].map((i) => (
-            <div key={i} className="flex items-center gap-3 p-3 bg-white/50 rounded-xl animate-pulse">
+            <div key={i} className="flex items-center gap-3 p-3 bg-card/50 rounded-xl animate-pulse">
               <div className="w-9 h-9 md:w-10 md:h-10 bg-muted rounded-lg" />
               <div className="flex-1 space-y-2">
                 <div className="h-4 bg-muted rounded w-3/4" />

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -121,8 +121,8 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
         <Section variant="plain" padding="none">
           <Card className="bg-gradient-to-r from-warm-coral/10 to-warm-peach/10 border-warm-coral/20">
             <CardContent className="p-6 text-center">
-              <Avatar className="w-20 h-20 mx-auto mb-4 bg-warm-coral text-white">
-                <AvatarFallback className="bg-warm-coral text-white text-lg">
+              <Avatar className="w-20 h-20 mx-auto mb-4 bg-primary text-primary-foreground">
+                <AvatarFallback className="bg-primary text-primary-foreground text-lg">
                   {getInitials()}
                 </AvatarFallback>
               </Avatar>
@@ -167,7 +167,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
         {/* Stats Overview */}
         <Section variant="plain" padding="none">
           <div className="grid grid-cols-3 gap-3">
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardContent className="p-4 text-center">
                 <div className="w-8 h-8 rounded-full bg-warm-coral/20 flex items-center justify-center mx-auto mb-2">
                   <Dumbbell size={16} className="text-warm-coral" />
@@ -177,7 +177,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
               </CardContent>
             </Card>
 
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardContent className="p-4 text-center">
                 <div className="w-8 h-8 rounded-full bg-warm-sage/20 flex items-center justify-center mx-auto mb-2">
                   <Calendar size={16} className="text-warm-sage" />
@@ -187,7 +187,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
               </CardContent>
             </Card>
 
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardContent className="p-4 text-center">
                 <div className="w-8 h-8 rounded-full bg-warm-peach/20 flex items-center justify-center mx-auto mb-2">
                   <TrendingUp size={16} className="text-warm-peach" />
@@ -209,7 +209,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
 
             <div className="space-y-2">
               {personalBests.map((pb, index) => (
-                <Card key={index} className="bg-white/80 backdrop-blur-sm">
+                <Card key={index} className="bg-card/80 backdrop-blur-sm">
                   <CardContent className="p-4">
                     <div className="flex justify-between items-center">
                       <div>

--- a/components/screens/ProgressScreen.tsx
+++ b/components/screens/ProgressScreen.tsx
@@ -131,7 +131,7 @@ export function ProgressScreen({ bottomBar }: ProgressScreenProps) {
         {/* Main Stat Cards */}
         <Section variant="plain" padding="none">
           <div className="grid grid-cols-2 gap-4">
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardContent className="p-6 flex flex-col items-center">
                 {isLoading ? (
                   <div className="text-warm-brown/60">Loading...</div>
@@ -148,7 +148,7 @@ export function ProgressScreen({ bottomBar }: ProgressScreenProps) {
               </CardContent>
             </Card>
 
-            <Card className="bg-white/80 backdrop-blur-sm">
+            <Card className="bg-card/80 backdrop-blur-sm">
               <CardContent className="p-6 flex flex-col items-center">
                 {isLoading ? (
                   <div className="text-warm-brown/60">Loading...</div>
@@ -169,7 +169,7 @@ export function ProgressScreen({ bottomBar }: ProgressScreenProps) {
 
         {/* Monthly Progress */}
         <Section variant="plain" padding="none">
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <div className="flex items-center gap-2">
                 <Calendar size={20} className="text-warm-peach" />
@@ -226,7 +226,7 @@ export function ProgressScreen({ bottomBar }: ProgressScreenProps) {
 
         {/* Achievements */}
         <Section variant="plain" padding="none">
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <div className="flex items-center gap-2">
                 <Award size={20} className="text-warm-mint" />
@@ -269,7 +269,7 @@ export function ProgressScreen({ bottomBar }: ProgressScreenProps) {
 
         {/* Trend Chart */}
         <Section variant="plain" padding="none">
-          <Card className="bg-white/80 backdrop-blur-sm">
+          <Card className="bg-card/80 backdrop-blur-sm">
             <CardHeader>
               <div className="flex items-center gap-2">
                 <TrendingUp size={20} className="text-warm-coral" />

--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -64,14 +64,14 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
       <Card
         className="
           w-full
-          bg-white/80 backdrop-blur-sm border-border
+          bg-card/80 backdrop-blur-sm border-border
           shadow-soft
         "
       >
         <CardHeader className="text-center pb-6">
           <Stack gap="md">
             <div className="w-16 h-16 rounded-2xl gradient-primary flex items-center justify-center mx-auto">
-              <Dumbbell size={32} className="text-white" />
+              <Dumbbell size={32} className="text-primary-foreground" />
             </div>
 
             <div>
@@ -125,12 +125,12 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
 
               <TactileButton
                 type="submit"
-                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-white"
+                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-primary-foreground"
                 disabled={isLoading}
               >
                 {isLoading ? (
                   <div className="flex items-center justify-center gap-2">
-                    <div className="w-4 h-4 animate-spin border-2 border-white border-t-transparent rounded-full" />
+                    <div className="w-4 h-4 animate-spin border-2 border-primary-foreground border-t-transparent rounded-full" />
                     Signing In...
                   </div>
                 ) : (

--- a/components/screens/SignUpScreen.tsx
+++ b/components/screens/SignUpScreen.tsx
@@ -112,7 +112,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
       <Card
         className="
           w-full max-w-md
-          bg-white/90 backdrop-blur-sm border-border
+          bg-card/90 backdrop-blur-sm border-border
           shadow-soft
           max-h-[100svh] overflow-y-auto
           pt-safe pb-safe kb-aware
@@ -135,7 +135,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
                     placeholder="First Name"
                     value={firstName}
                     onChange={(e) => setFirstName(e.target.value)}
-                    className="w-full px-4 py-3 rounded-xl border border-border bg-white/80 text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
+                    className="w-full px-4 py-3 rounded-xl border border-border bg-input-background text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
                     disabled={isLoading}
                     autoComplete="given-name"
                     required
@@ -147,7 +147,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
                     placeholder="Last Name"
                     value={lastName}
                     onChange={(e) => setLastName(e.target.value)}
-                    className="w-full px-4 py-3 rounded-xl border border-border bg-white/80 text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
+                    className="w-full px-4 py-3 rounded-xl border border-border bg-input-background text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
                     disabled={isLoading}
                     autoComplete="family-name"
                     required
@@ -161,7 +161,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
                   placeholder="Display Name"
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
-                  className="w-full px-4 py-3 rounded-xl border border-border bg-white/80 text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
+                  className="w-full px-4 py-3 rounded-xl border border-border bg-input-background text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
                   disabled={isLoading}
                   autoComplete="nickname"
                   required
@@ -175,7 +175,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
                     placeholder="Height (cm)"
                     value={height}
                     onChange={(e) => setHeight(e.target.value)}
-                    className="w-full px-4 py-3 rounded-xl border border-border bg-white/80 text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
+                    className="w-full px-4 py-3 rounded-xl border border-border bg-input-background text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
                     disabled={isLoading}
                     min="1"
                   />
@@ -186,7 +186,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
                     placeholder="Weight (kg)"
                     value={weight}
                     onChange={(e) => setWeight(e.target.value)}
-                    className="w-full px-4 py-3 rounded-xl border border-border bg-white/80 text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
+                    className="w-full px-4 py-3 rounded-xl border border-border bg-input-background text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
                     disabled={isLoading}
                     min="1"
                   />
@@ -199,7 +199,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
                   placeholder="Email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="w-full px-4 py-3 rounded-xl border border-border bg-white/80 text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
+                  className="w-full px-4 py-3 rounded-xl border border-border bg-input-background text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
                   disabled={isLoading}
                   autoComplete="email"
                   required
@@ -212,7 +212,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
                   placeholder="Password (min 6 characters)"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-4 py-3 rounded-xl border border-border bg-white/80 text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
+                  className="w-full px-4 py-3 rounded-xl border border-border bg-input-background text-warm-brown placeholder:text-warm-brown/50 focus:outline-none focus:ring-2 focus:ring-warm-coral/30 focus:border-warm-coral"
                   disabled={isLoading}
                   autoComplete="new-password"
                   required
@@ -222,11 +222,11 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
               <TactileButton
                 type="submit"
                 disabled={disabledSubmit}
-                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-white disabled:opacity-60 disabled:cursor-not-allowed"
+                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-primary-foreground disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {isLoading ? (
                   <div className="flex items-center justify-center gap-2">
-                    <div className="w-4 h-4 animate-spin border-2 border-white border-t-transparent rounded-full" />
+                    <div className="w-4 h-4 animate-spin border-2 border-primary-foreground border-t-transparent rounded-full" />
                     Creating Account...
                   </div>
                 ) : (

--- a/components/screens/WorkoutDashboardScreen.tsx
+++ b/components/screens/WorkoutDashboardScreen.tsx
@@ -270,7 +270,7 @@ export default function WorkoutDashboardScreen({
           {canEdit && (
             <TactileButton
               onClick={onCreateRoutine}
-              className="bg-warm-coral hover:bg-warm-coral/90 text-white px-4 py-2 text-sm font-medium rounded-xl"
+              className="bg-primary hover:bg-primary-hover text-primary-foreground px-4 py-2 text-sm font-medium rounded-xl"
             >
               Create Routine
             </TactileButton>
@@ -298,10 +298,10 @@ export default function WorkoutDashboardScreen({
                   }
                 >
                   <div className="text-center py-4">
-                    <div className="w-12 h-12 mx-auto mb-3 bg-red-100 rounded-full flex items-center justify-center">
-                      <AlertCircle className="w-5 h-5 text-red-500" />
+                    <div className="w-12 h-12 mx-auto mb-3 bg-destructive-light rounded-full flex items-center justify-center">
+                      <AlertCircle className="w-5 h-5 text-destructive" />
                     </div>
-                    <p className="text-red-600 text-sm">{routinesError}</p>
+                    <p className="text-destructive text-sm">{routinesError}</p>
                   </div>
                 </Section>
               ) : routines.length === 0 ? (
@@ -334,7 +334,7 @@ export default function WorkoutDashboardScreen({
                         className="
                           w-full
                           rounded-2xl border border-border
-                          bg-white shadow-sm hover:shadow-md transition-all
+                          bg-card shadow-sm hover:shadow-md transition-all
                           p-4
                           text-left
                         "
@@ -342,7 +342,7 @@ export default function WorkoutDashboardScreen({
                         <div className="flex items-center justify-between gap-3">
                           <div className="flex items-center gap-3 min-w-0">
                             <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${palette.bg}`}>
-                              <div className={`w-8 h-8 ${palette.iconBg} rounded-lg grid place-items-center text-white text-lg`}>
+                              <div className={`w-8 h-8 ${palette.iconBg} rounded-lg grid place-items-center text-primary-foreground text-lg`}>
                                 <span>{palette.emoji}</span>
                               </div>
                             </div>

--- a/components/segmented/SegmentedToggle.tsx
+++ b/components/segmented/SegmentedToggle.tsx
@@ -60,7 +60,7 @@ export default function SegmentedToggle<V extends string = string>({
       role="tablist"
       aria-label="Segmented toggle"
       className={cx(
-        "inline-flex items-center rounded-lg border border-border bg-white/70 backdrop-blur-sm p-0.5 gap-1",
+        "inline-flex items-center rounded-lg border border-border bg-card/70 backdrop-blur-sm p-0.5 gap-1",
         className
       )}
     >
@@ -89,9 +89,9 @@ export default function SegmentedToggle<V extends string = string>({
         const filledSelected = cx(
           s.pad,
           s.text,
-          "font-medium text-white",
+          "font-medium text-primary-foreground",
           t.border,
-          "bg-warm-coral"
+          "bg-primary"
         );
         const filledIdle = cx(
           s.pad,

--- a/components/sets/ExerciseSetEditorCard.tsx
+++ b/components/sets/ExerciseSetEditorCard.tsx
@@ -49,7 +49,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
   primaryDisabled = false,
 }) => {
   return (
-    <div className={["rounded-2xl bg-white/70 border border-border p-3 md:p-4", className].join(" ")}
+    <div className={["rounded-2xl bg-card/70 border border-border p-3 md:p-4", className].join(" ")}
     /* RAVI DBG: style={{ border: "2px solid red" }}*/>
       {note && (
         <p className="text-xs md:text-sm text-muted-foreground mb-3 italic bg-[var(--warm-cream)]/50 p-3 rounded-lg">
@@ -78,7 +78,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
             size="sm"
             onClick={onCancel}
             disabled={disabled}
-            className={`p-3 h-auto bg-white/70 border-red-200 text-red-500 hover:bg-red-50 btn-tactile ${
+            className={`p-3 h-auto bg-card/70 border-destructive-light text-destructive hover:bg-destructive-light btn-tactile ${
               disabled ? "opacity-50 cursor-not-allowed" : ""
             }`}
             title="Cancel"
@@ -94,7 +94,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
           <TactileButton
             onClick={onPrimary}
             disabled={primaryDisabled || disabled}
-            className={`w-full h-12 md:h-14 bg-warm-coral text-white font-medium rounded-full hover:bg-warm-coral/90 btn-tactile ${
+            className={`w-full h-12 md:h-14 bg-primary text-primary-foreground font-medium rounded-full hover:bg-primary-hover btn-tactile ${
               primaryDisabled || disabled ? "opacity-50 cursor-not-allowed" : ""
             }`}
           >

--- a/components/sets/SetList.tsx
+++ b/components/sets/SetList.tsx
@@ -134,7 +134,7 @@ const SetList: React.FC<SetListProps> = ({
                 onFocus={onFocusScroll}
                 onChange={(e) => onChange?.(it.key, "reps", e.target.value)}
                 disabled={readOnly}
-                className={`bg-white border-border text-foreground text-center h-10 md:h-8 rounded-md focus:border-warm-sage focus:ring-warm-sage/20 text-sm ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
+                className={`bg-input-background border-border text-foreground text-center h-10 md:h-8 rounded-md focus:border-warm-sage focus:ring-warm-sage/20 text-sm ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
                 min="0"
               />
 
@@ -147,7 +147,7 @@ const SetList: React.FC<SetListProps> = ({
                 onFocus={onFocusScroll}
                 onChange={(e) => onChange?.(it.key, "weight", e.target.value)}
                 disabled={readOnly}
-                className={`bg-white border-border text-foreground text-center h-10 md:h-8 rounded-md focus:border-warm-sage/20 text-sm ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
+                className={`bg-input-background border-border text-foreground text-center h-10 md:h-8 rounded-md focus:border-warm-sage/20 text-sm ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
                 min="0"
               />
 
@@ -156,7 +156,7 @@ const SetList: React.FC<SetListProps> = ({
                   variant="secondary"
                   size="sm"
                   onClick={() => onRemove?.(it.key)}
-                  className="p-1 h-auto bg-red-50 text-red-500 hover:bg-red-100 ml-auto"
+                  className="p-1 h-auto bg-destructive-light text-destructive hover:bg-destructive ml-auto"
                   title="Remove this set"
                 >
                   <X size={14} />
@@ -177,7 +177,7 @@ const SetList: React.FC<SetListProps> = ({
           {onAdd ? (
             <TactileButton
               onClick={onAdd}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg btn-tactile bg-white/70 border-border text-foreground hover:bg-white"
+              className="flex items-center gap-2 px-4 py-2 rounded-lg btn-tactile bg-card/70 border-border text-foreground hover:bg-card"
               disabled={isDisabled}
               title={
                 isDisabled
@@ -205,7 +205,7 @@ const SetList: React.FC<SetListProps> = ({
               disabled={deleteDisabled || readOnly}
               className={`p-2 h-auto rounded-lg ${deleteDisabled || readOnly
                 ? "opacity-50 cursor-not-allowed"
-                : "bg-red-50 text-red-600 hover:bg-red-100"
+                : "bg-destructive-light text-destructive hover:bg-destructive"
                 }`}
               title={deleteTitle}
             >

--- a/components/sheets/BottomSheets.tsx
+++ b/components/sheets/BottomSheets.tsx
@@ -58,13 +58,13 @@ export default function BottomSheet({
         >
           <div
             className={cx(
-              "bg-white rounded-t-2xl shadow-2xl border-t border-x border-border overflow-hidden",
+              "bg-card rounded-t-2xl shadow-2xl border-t border-x border-border overflow-hidden",
               innerClassName
             )}
             style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
           >
             <div className="flex justify-center py-2">
-              <div className="h-1.5 w-10 rounded-full bg-gray-200" />
+              <div className="h-1.5 w-10 rounded-full bg-border" />
             </div>
 
             {header ? <div className="px-4 pb-2">{header}</div> : null}

--- a/components/sheets/RoutineActionsSheets.tsx
+++ b/components/sheets/RoutineActionsSheets.tsx
@@ -61,7 +61,7 @@ export default function RoutineActionsSheet({
               Rename
             </button>
             <button
-              className="w-full text-left px-4 py-4 hover:bg-red-50 text-red-600"
+              className="w-full text-left px-4 py-4 hover:bg-destructive-light text-destructive"
               onClick={() => setMode("confirmDelete")}
             >
               Delete
@@ -127,7 +127,7 @@ export default function RoutineActionsSheet({
           </p>
           <div className="flex gap-3 pt-1">
             <TactileButton
-              className="flex-1 bg-red-600 hover:bg-red-700 text-white"
+              className="flex-1 bg-destructive hover:bg-destructive/90 text-primary-foreground"
               onClick={onRequestDelete}
               disabled={deleteLoading}
             >

--- a/components/system/ErrorBoundary.tsx
+++ b/components/system/ErrorBoundary.tsx
@@ -12,7 +12,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     logger.error("[ErrorBoundary]", err, info);
   }
   render() {
-    if (this.state.hasError) return this.props.fallback ?? <div className="p-4 text-red-600">Something went wrong.</div>;
+    if (this.state.hasError) return this.props.fallback ?? <div className="p-4 text-destructive">Something went wrong.</div>;
     return this.props.children;
   }
 }

--- a/components/ui/ExpandingCard.tsx
+++ b/components/ui/ExpandingCard.tsx
@@ -32,9 +32,9 @@ type Props = React.PropsWithChildren<BaseProps>;
 
 const containerByVariant: Record<Variant, string> = {
   glass:
-    "rounded-2xl border overflow-hidden backdrop-blur-md bg-white/[0.04] border-white/10 shadow-xl shadow-black/40",
+    "rounded-2xl border overflow-hidden backdrop-blur-md bg-card/4 border-border shadow-xl shadow-black/40",
   solid:
-    "rounded-2xl border overflow-hidden bg-white/80 border-border shadow-sm",
+    "rounded-2xl border overflow-hidden bg-card/80 border-border shadow-sm",
   plain: "rounded-2xl overflow-hidden",
 };
 
@@ -68,7 +68,7 @@ export default function ExpandingCard({
       initial={false}
       className={[
         containerByVariant[variant],
-        expanded ? "ring-1 ring-white/[0.06]" : "",
+        expanded ? "ring-1 ring-border" : "",
         className,
       ].join(" ")}
     >
@@ -81,11 +81,11 @@ export default function ExpandingCard({
           "w-full flex items-center gap-3 text-left select-none",
           headerPadBySize[size],
           headerClassName,
-          disabled ? "opacity-60 cursor-default" : "hover:bg-white/[0.03]",
+          disabled ? "opacity-60 cursor-default" : "hover:bg-card/3",
         ].join(" ")}
       >
         {leading && (
-          <div className="w-12 h-12 rounded-xl overflow-hidden bg-white/10 flex items-center justify-center shrink-0">
+          <div className="w-12 h-12 rounded-xl overflow-hidden bg-card/10 flex items-center justify-center shrink-0">
             {leading}
           </div>
         )}
@@ -94,7 +94,7 @@ export default function ExpandingCard({
           <div
             className={[
               "truncate font-semibold",
-              variant === "glass" ? "text-white/95" : "text-foreground",
+              variant === "glass" ? "text-primary-foreground opacity-95" : "text-foreground",
             ].join(" ")}
           >
             {title}
@@ -103,7 +103,7 @@ export default function ExpandingCard({
             <div
               className={[
                 "truncate text-sm",
-                variant === "glass" ? "text-white/60" : "text-muted-foreground",
+                variant === "glass" ? "text-primary-foreground opacity-60" : "text-muted-foreground",
               ].join(" ")}
             >
               {subtitle}
@@ -119,7 +119,7 @@ export default function ExpandingCard({
             transition={{ type: "spring", stiffness: 300, damping: 24 }}
             className={[
               "ml-1",
-              variant === "glass" ? "text-white/70" : "text-warm-brown/70",
+              variant === "glass" ? "text-primary-foreground opacity-70" : "text-warm-brown/70",
             ].join(" ")}
           >
             <ChevronDown size={18} />
@@ -139,7 +139,7 @@ export default function ExpandingCard({
             className={[
               "pt-1 pb-4 px-4",
               bodyClassName,
-              variant === "glass" ? "text-white/90" : "text-foreground",
+              variant === "glass" ? "text-primary-foreground opacity-90" : "text-foreground",
             ].join(" ")}
           >
             {children}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border-transparent bg-destructive text-primary-foreground [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,7 +9,8 @@
   /* Core Colors - Modern & Accessible */
   --background: #fefcfb;
   --foreground: #3d2914;
-  --card: #ffffff;
+  --card-hsl: 0 0% 100%;
+  --card: hsl(var(--card-hsl));
   --card-foreground: #3d2914;
   --popover: #ffffff;
   --popover-foreground: #3d2914;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ export default {
       colors: {
         /* App surface tokens */
         background: "var(--background)",
-        card: "var(--card)",
+        card: "hsl(var(--card-hsl))",
         "card-foreground": "var(--card-foreground)",
         popover: "var(--popover)",
         "popover-foreground": "var(--popover-foreground)",


### PR DESCRIPTION
## Summary
- use `card` token for surfaces and support alpha overlays
- swap `text-white` usages for `text-primary-foreground`
- standardize inputs and buttons on semantic color tokens

## Testing
- `npm test` *(fails: logger is not defined in auth-integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b715fe27048321900a1db4e56f5fd5