### PR TITLE
Use theme tokens for circular stats

### DIFF
--- a/components/circularStat/CircularStat.tsx
+++ b/components/circularStat/CircularStat.tsx
@@ -1,3 +1,5 @@
+import { useThemeTokens } from "./useThemeTokens";
+
 export type CircularStatProps = {
   value: number | null | undefined;
   max?: number;
@@ -23,12 +25,16 @@ export default function CircularStat({
   size = 112,
   strokeWidth = 10,
   decimals = 0,
-  trackColor = "#e5e7eb",
-  progressColor = "#e07a5f",
-  textColor = "#3d2914",
+  trackColor,
+  progressColor,
+  textColor,
   primaryTextOverride,
   secondaryTextOverride,
 }: CircularStatProps) {
+  const { warmBrown, warmCoral, trackGray } = useThemeTokens();
+  const resolvedTrack = trackColor ?? trackGray;
+  const resolvedProgress = progressColor ?? warmCoral;
+  const resolvedText = textColor ?? warmBrown;
   const safeValue =
     typeof value === "number" && isFinite(value)
       ? Math.max(0, Math.min(value, max))
@@ -45,8 +51,8 @@ export default function CircularStat({
       <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="block">
         <defs>
           <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stopColor={progressColor} />
-            <stop offset="100%" stopColor={progressColor} />
+            <stop offset="0%" stopColor={resolvedProgress} />
+            <stop offset="100%" stopColor={resolvedProgress} />
           </linearGradient>
         </defs>
 
@@ -54,7 +60,7 @@ export default function CircularStat({
           cx={size / 2}
           cy={size / 2}
           r={radius}
-          stroke={trackColor}
+          stroke={resolvedTrack}
           strokeWidth={strokeWidth}
           fill="none"
           strokeLinecap="round"
@@ -87,7 +93,7 @@ export default function CircularStat({
           <text
             textAnchor="middle"
             dominantBaseline="central"
-            style={{ fontSize: size * 0.24, fontWeight: 700, fill: textColor }}
+            style={{ fontSize: size * 0.24, fontWeight: 700, fill: resolvedText }}
           >
             {primaryTextOverride ?? (safeValue == null ? "—" : safeValue.toFixed(decimals))}
           </text>
@@ -95,14 +101,14 @@ export default function CircularStat({
             y={size * 0.18}
             textAnchor="middle"
             dominantBaseline="hanging"
-            style={{ fontSize: size * 0.14, fontWeight: 600, fill: textColor, opacity: 0.5 }}
+            style={{ fontSize: size * 0.14, fontWeight: 600, fill: resolvedText, opacity: 0.5 }}
           >
             {secondaryTextOverride ?? unit}
           </text>
         </g>
       </svg>
 
-      <div className="mt-2 text-xs" style={{ color: textColor, opacity: 0.75 }}>
+      <div className="mt-2 text-xs" style={{ color: resolvedText, opacity: 0.75 }}>
         {label}
       </div>
     </div>

--- a/components/circularStat/ProgressRings.tsx
+++ b/components/circularStat/ProgressRings.tsx
@@ -50,7 +50,8 @@ function ProgressRings({
   onRecoveryClick,
   onStrainClick,
 }: ProgressRingsProps) {
-  const { warmBrown, warmCoral, accentBlue, trackGray } = useThemeTokens();
+  const { warmBrown, warmCoral, accentBlue, trackGray, recoveryYellow } =
+    useThemeTokens();
   const vw = useViewportWidth();
 
   // scale ring size with viewport width (keeps 3 across on all phones)
@@ -97,7 +98,7 @@ function ProgressRings({
           size={ring}
           strokeWidth={ringStroke}
           textColor={warmBrown}
-          progressColor={"#f2c94c"}
+          progressColor={recoveryYellow}
           trackColor={trackGray}
         />
       ),
@@ -139,7 +140,7 @@ function ProgressRings({
       </div>
 
       {/* subtle divider */}
-      <div className="mt-3 h-px bg-black/5" />
+      <div className="mt-3 h-px bg-foreground/5" />
     </div>
   );
 }

--- a/components/circularStat/useThemeTokens.ts
+++ b/components/circularStat/useThemeTokens.ts
@@ -1,17 +1,17 @@
 export function useThemeTokens() {
-    const css =
-      typeof window !== "undefined" && typeof document !== "undefined"
-        ? getComputedStyle(document.documentElement)
-        : null;
-  
-    const read = (name: string, fallback: string) =>
-      css?.getPropertyValue(name)?.trim() || fallback;
-  
-    return {
-      warmBrown: read("--foreground", "#3d2914"),
-      warmCoral: read("--primary", "#e07a5f"),
-      accentBlue: read("--accent-blue", "#4aa3df"),
-      trackGray: read("--ring-track-gray", "#d1d5db"),
-    };
-  }
+  const css =
+    typeof window !== "undefined" && typeof document !== "undefined"
+      ? getComputedStyle(document.documentElement)
+      : null;
+
+  const read = (name: string) => css?.getPropertyValue(name)?.trim() || "";
+
+  return {
+    warmBrown: read("--foreground"),
+    warmCoral: read("--primary"),
+    accentBlue: read("--accent-blue"),
+    trackGray: read("--ring-track-gray"),
+    recoveryYellow: read("--recovery-yellow"),
+  };
+}
   

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -106,6 +106,11 @@
   --soft-gray: #f7f3f0;
   --warm-brown: #8b7766;
 
+  /* Additional tokens for progress components */
+  --accent-blue: #4aa3df;
+  --ring-track-gray: #d1d5db;
+  --recovery-yellow: #f2c94c;
+
   --app-header-h: 56px;
   --app-bottom-h: 64px;
 
@@ -125,6 +130,11 @@
   --warm-rose-hsl: 355.38 53.06% 80.78%;
   --warm-lavender-hsl: 280.56 63.96% 78.24%;
   --soft-gray-hsl: 25.71 30.43% 95.49%;
+
+  /* Progress component HSL tokens */
+  --accent-blue-hsl: 204.16 69.95% 58.24%;
+  --ring-track-gray-hsl: 216 12.2% 83.92%;
+  --recovery-yellow-hsl: 45.18 86.46% 62.35%;
 
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,9 @@ export default {
         "warm-rose": "hsl(var(--warm-rose-hsl))",
         "warm-lavender": "hsl(var(--warm-lavender-hsl))",
         "soft-gray": "hsl(var(--soft-gray-hsl))",
+        "accent-blue": "hsl(var(--accent-blue-hsl))",
+        "ring-track-gray": "hsl(var(--ring-track-gray-hsl))",
+        "recovery-yellow": "hsl(var(--recovery-yellow-hsl))",
 
         /* Keep raw background/muted as vars (not HSL) if you prefer */
         muted: "var(--muted)",


### PR DESCRIPTION
## Summary
- replace hard-coded circular stat colors with theme tokens
- add accent blue, track gray, and recovery yellow tokens
- expose token reader in useThemeTokens hook

## Testing
- `npm test` *(fails: ReferenceError logger is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7174f66dc8321a41a825caee8816b