### PR TITLE
feat: add dark mode theme tokens and toggle

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import { useAppNavigation } from "./hooks/useAppNavigation";
 import { useMobileSetup } from "./hooks/useMobileSetup";
 import { Toaster } from "./components/ui/sonner";
 import { useState } from "react";
+import ThemeToggle from "./components/ThemeToggle";
 
 import { BottomNavigation, TabType } from "./components/BottomNavigation";
 import { VIEWS_WITHOUT_BOTTOM_NAV } from "./utils/navigation";
@@ -66,7 +67,8 @@ function AppContent() {
   }
 
   return (
-    <div id="app" className="h-dvh flex flex-col overflow-hidden">
+    <div id="app" className="relative h-dvh flex flex-col overflow-hidden">
+      <ThemeToggle className="absolute top-2 right-2" />
       <main className="flex-1 min-h-0 overflow-hidden">
         <AppRouter
           currentView={currentView}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const [isDark, setIsDark] = useState(() =>
+    typeof window !== "undefined" && document.documentElement.classList.contains("dark")
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    window.dispatchEvent(new CustomEvent("themechange", { detail: { isDark } }));
+  }, [isDark]);
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={() => setIsDark((prev) => !prev)}
+      className={`p-2 rounded-md border transition-colors ${className ?? ""}`}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}
+
+export default ThemeToggle;

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "./utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {
@@ -14,7 +14,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/40",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,9 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input flex h-9 w-full min-w-0 rounded-md border px-3 py-1 text-base bg-input-background transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,
       )}
       {...props}

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,11 +1,23 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Toaster as Sonner, ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
+  const [theme, setTheme] = useState<"light" | "dark">(() =>
+    document.documentElement.classList.contains("dark") ? "dark" : "light"
+  );
+
+  useEffect(() => {
+    const handleChange = () =>
+      setTheme(document.documentElement.classList.contains("dark") ? "dark" : "light");
+    window.addEventListener("themechange", handleChange);
+    return () => window.removeEventListener("themechange", handleChange);
+  }, []);
+
   return (
     <Sonner
-      theme="light"
+      theme={theme}
       className="toaster group"
       style={
         {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -128,6 +128,64 @@
 
 }
 
+.dark,
+[data-theme="dark"] {
+  /* Core Colors - Dark Mode */
+  --background: #0f0f0f;
+  --foreground: #f5f5f5;
+  --card: #1a1a1a;
+  --card-foreground: #f5f5f5;
+  --popover: #1a1a1a;
+  --popover-foreground: #f5f5f5;
+
+  /* Primary Brand Colors */
+  --primary: #e07a5f;
+  --primary-foreground: #ffffff;
+  --primary-hover: #cf694f;
+  --primary-light: #4a2a22;
+
+  /* Secondary & Accent */
+  --secondary: #3f3727;
+  --secondary-foreground: #f5f5f5;
+  --accent: #56756b;
+  --accent-foreground: #ffffff;
+  --accent-light: #2d3f36;
+
+  /* Semantic Colors */
+  --success: #3fa969;
+  --success-light: #1e4932;
+  --warning: #e9b949;
+  --warning-light: #4a3d1f;
+  --destructive: #e74c5b;
+  --destructive-light: #4f1f25;
+  --info: #209fb5;
+  --info-light: #163f4a;
+
+  /* Neutral Colors */
+  --muted: #1e1e1e;
+  --muted-foreground: #d4d4d8;
+  --border: rgba(224, 122, 95, 0.3);
+  --border-light: #2d2d2d;
+  --input: #1e1e1e;
+  --input-background: #1e1e1e;
+  --input-border: #3f3f46;
+  --input-focus: #e07a5f;
+
+  /* HSL triplets for Tailwind /opacity support */
+  --foreground-hsl: 0 0% 96%;
+  --primary-hsl: 12.56 67.54% 62.55%;
+  --muted-foreground-hsl: 240 5% 65%;
+  --warm-brown-hsl: 27.57 15.35% 47.25%;
+  --warm-coral-hsl: 12.56 67.54% 62.55%;
+  --warm-sage-hsl: 108.33 23.38% 69.80%;
+  --warm-cream-hsl: 45.88 69.86% 85.69%;
+  --warm-peach-hsl: 36.97 79.20% 75.49%;
+  --warm-mint-hsl: 150.61 24.14% 60.20%;
+  --warm-rose-hsl: 355.38 53.06% 80.78%;
+  --warm-lavender-hsl: 280.56 63.96% 78.24%;
+  --soft-gray-hsl: 0 0% 20%;
+}
+
 @layer base {
 
   html,


### PR DESCRIPTION
## Summary
- define dark-mode CSS tokens for surfaces, text, borders, overlays, and semantic colors
- add ThemeToggle component to apply/remove `dark` class on root and update Toaster
- rely on CSS variables for automatic theming in badges and inputs

## Testing
- `npm test` *(fails: ReferenceError: logger is not defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7175318448321862baac51d285763