### PR TITLE
feat: add workout mode scaffolding

### DIFF
--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -49,6 +49,7 @@ type UISet = {
   set_order: number;
   reps: string; // keep strings for controlled inputs
   weight: string;
+  done?: boolean;
 };
 
 type UIExercise = {
@@ -101,7 +102,12 @@ export function ExerciseSetupScreen({
   const [exercises, setExercises] = useState<UIExercise[]>([]);
   const [loadingSaved, setLoadingSaved] = useState(true);
   const [savingAll, setSavingAll] = useState(false);
+  const [savingWorkout, setSavingWorkout] = useState(false);
   const [loadingSets, setLoadingSets] = useState<Record<string, boolean>>({}); // key by exercise id as string
+
+  type ScreenMode = "plan" | "workout";
+  const [screenMode, setScreenMode] = useState<ScreenMode>("plan");
+  const inWorkout = screenMode === "workout";
 
   // Append-only action journal (doesn't trigger re-renders)
   const journalRef = useRef(makeJournal());
@@ -279,7 +285,7 @@ export function ExerciseSetupScreen({
         muscle_group: muscle_group || undefined,
         loaded: true,
         expanded: true,
-        sets: [{ id: initialSetId, set_order: 1, reps: "0", weight: "0" }],
+        sets: [{ id: initialSetId, set_order: 1, reps: "0", weight: "0", ...(inWorkout ? { done: false } : {}) }],
       },
     ]);
 
@@ -338,6 +344,7 @@ export function ExerciseSetupScreen({
         set_order: nextOrder,
         reps: initialReps,
         weight: initialWeight,
+        ...(inWorkout ? { done: false } : {}),
       });
 
       recordSetAdd(journalRef.current, exId, newSetId, nextOrder, initialReps, initialWeight);
@@ -417,6 +424,79 @@ export function ExerciseSetupScreen({
     if (access === RoutineAccess.ReadOnly) return;
     setExercises((prev) => prev.filter((e) => e.id !== exId));
     recordExDelete(journalRef.current, exId);
+  };
+
+  const onToggleDone = (exId: Id, rawKey: unknown, done: boolean) => {
+    withExercises((draft) => {
+      const ex = draft.find((d) => d.id === exId);
+      if (!ex) return;
+      const setId = resolveSetId(ex, rawKey);
+      if (setId == null) return;
+      const s = ex.sets.find((st) => st.id === setId);
+      if (s) s.done = done;
+    });
+  };
+
+  const startWorkout = () => {
+    // reset any stale journal entries and mark all sets as not done locally
+    journalRef.current = makeJournal();
+    setExercises((prev) =>
+      prev.map((ex) => ({
+        ...ex,
+        sets: ex.sets.map((s) => ({ ...s, done: false })),
+      }))
+    );
+    setScreenMode("workout");
+  };
+
+  const endWorkout = async () => {
+    if (!userToken) {
+      toast.error("Please sign in to save workout");
+      return;
+    }
+
+    setSavingWorkout(true);
+    try {
+      // Persist workout session in one go at workout end
+      const workout = await supabaseAPI.startWorkout(routineId);
+
+      for (let i = 0; i < exercises.length; i++) {
+        const ex = exercises[i];
+        const wEx = await supabaseAPI.addWorkoutExercise(workout.id, ex.exerciseId, i + 1);
+        for (const s of ex.sets) {
+          await supabaseAPI.addWorkoutSet(
+            wEx.id,
+            s.set_order,
+            Number(s.reps) || 0,
+            Number(s.weight) || 0,
+            s.done ? new Date().toISOString() : undefined
+          );
+        }
+      }
+
+      await supabaseAPI.endWorkout(workout.id);
+
+      // Apply workout edits to the routine template
+      const journal = journalRef.current;
+      const exIdMap: ExIdMap = {};
+      for (const e of exercises) {
+        exIdMap[e.id] = { templateId: e.templateId, exerciseId: e.exerciseId };
+      }
+      const plan = collapseJournal(journal);
+      if (!journalIsNoop(journal)) {
+        await runJournal(plan, routineId, exIdMap);
+      }
+      journalRef.current = makeJournal();
+
+      await reloadFromDb();
+      toast.success("Workout saved!");
+      setScreenMode("plan");
+    } catch (e) {
+      logger.error(String(e));
+      toast.error("Failed to save workout");
+    } finally {
+      setSavingWorkout(false);
+    }
   };
 
   /* =======================================================================================
@@ -513,36 +593,62 @@ export function ExerciseSetupScreen({
     />
   );
 
-  const renderBottomBar = () =>
-    hasUnsaved ? (
-      <FooterBar size="md" bg="translucent" align="between" maxContent="responsive" innerClassName="w-full gap-3">
-        <div className="flex w-full gap-3">
+  const renderBottomBar = () => {
+    if (screenMode === "plan") {
+      if (hasUnsaved) {
+        return (
+          <FooterBar size="md" bg="translucent" align="between" maxContent="responsive" innerClassName="w-full gap-3">
+            <div className="flex w-full gap-3">
+              <TactileButton
+                variant="secondary"
+                onClick={onCancelAll}
+                disabled={access === RoutineAccess.ReadOnly}
+                className={`flex-1 h-11 md:h-12 ${
+                  access === RoutineAccess.ReadOnly
+                    ? "opacity-50 cursor-not-allowed bg-gray-100 text-gray-400 border-gray-200"
+                    : "bg-transparent border-warm-brown/20 text-warm-brown/60 hover:bg-soft-gray"
+                } font-medium`}
+              >
+                CANCEL ALL
+              </TactileButton>
+              <TactileButton
+                onClick={onSaveAll}
+                disabled={savingAll || access === RoutineAccess.ReadOnly}
+                className={`flex-1 h-11 md:h-12 font-medium border-0 transition-all ${
+                  access === RoutineAccess.ReadOnly
+                    ? "opacity-50 cursor-not-allowed bg-gray-400"
+                    : "bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
+                }`}
+              >
+                {savingAll ? "SAVING..." : `SAVE ALL`}
+              </TactileButton>
+            </div>
+          </FooterBar>
+        );
+      }
+      return (
+        <FooterBar size="md" bg="translucent" align="center" maxContent="responsive" innerClassName="w-full">
           <TactileButton
-            variant="secondary"
-            onClick={onCancelAll}
-            disabled={access === RoutineAccess.ReadOnly}
-            className={`flex-1 h-11 md:h-12 ${
-              access === RoutineAccess.ReadOnly
-                ? "opacity-50 cursor-not-allowed bg-gray-100 text-gray-400 border-gray-200"
-                : "bg-transparent border-warm-brown/20 text-warm-brown/60 hover:bg-soft-gray"
-            } font-medium`}
+            onClick={startWorkout}
+            className="w-full h-11 md:h-12 bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
           >
-            CANCEL ALL
+            START WORKOUT
           </TactileButton>
-          <TactileButton
-            onClick={onSaveAll}
-            disabled={savingAll || access === RoutineAccess.ReadOnly}
-            className={`flex-1 h-11 md:h-12 font-medium border-0 transition-all ${
-              access === RoutineAccess.ReadOnly
-                ? "opacity-50 cursor-not-allowed bg-gray-400"
-                : "bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
-            }`}
-          >
-            {savingAll ? "SAVING..." : `SAVE ALL`}
-          </TactileButton>
-        </div>
+        </FooterBar>
+      );
+    }
+    return (
+      <FooterBar size="md" bg="translucent" align="center" maxContent="responsive" innerClassName="w-full">
+        <TactileButton
+          onClick={endWorkout}
+          disabled={savingWorkout}
+          className="w-full h-11 md:h-12 bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
+        >
+          {savingWorkout ? "SAVING..." : "END WORKOUT"}
+        </TactileButton>
       </FooterBar>
-    ) : null;
+    );
+  };
 
   const renderExerciseCard = (ex: UIExercise) => {
     const isLoading = !!loadingSets[String(ex.id)];
@@ -557,6 +663,7 @@ export function ExerciseSetupScreen({
             reps: s.reps,
             weight: s.weight,
             removable: ex.sets.length > 1,
+            done: s.done,
           }))
       : [];
 
@@ -600,12 +707,14 @@ export function ExerciseSetupScreen({
               name={ex.name}
               initials={ex.name.substring(0, 2)}
               items={items}
+              mode={inWorkout ? "workout" : "edit"}
               onChange={(key, field, value) =>
                 onChangeSet(ex.id, key as unknown, field as "reps" | "weight", value)
               }
-              onRemove={(key) => onRemoveSet(ex.id, key as unknown)}
+              onRemove={inWorkout ? undefined : (key) => onRemoveSet(ex.id, key as unknown)}
               onAdd={() => onAddSet(ex.id)}
-              onDeleteExercise={() => onDeleteExercise(ex.id)}
+              onDeleteExercise={inWorkout ? undefined : () => onDeleteExercise(ex.id)}
+              onToggleDone={inWorkout ? (key, done) => onToggleDone(ex.id, key, done) : undefined}
               deleteDisabled={access === RoutineAccess.ReadOnly}
               disabled={access === RoutineAccess.ReadOnly}
               onFocusScroll={(e) =>
@@ -657,7 +766,7 @@ export function ExerciseSetupScreen({
       header={renderHeader()}
       maxContent="responsive"
       padContent={false}
-      contentBottomPaddingClassName={hasUnsaved ? "pb-24" : ""}
+      contentBottomPaddingClassName={hasUnsaved || inWorkout ? "pb-24" : ""}
       bottomBar={renderBottomBar()}
       showHeaderBorder={false}
       showBottomBarBorder={false}

--- a/components/sets/ExerciseSetEditorCard.tsx
+++ b/components/sets/ExerciseSetEditorCard.tsx
@@ -1,7 +1,7 @@
 // components/sets/ExerciseSetEditorCard.tsx
 import * as React from "react";
 import { TactileButton } from "../TactileButton";
-import SetList, { SetListItem } from "./SetList";
+import SetList, { SetListItem, SetListMode } from "./SetList";
 import { Trash2 } from "lucide-react";
 
 type Props = {
@@ -12,11 +12,14 @@ type Props = {
   onChange?: (key: string | number, field: "reps" | "weight", value: string) => void;
   onRemove?: (key: string | number) => void;
   onAdd?: () => void;
+  onToggleDone?: (key: string | number, done: boolean) => void;
 
   // Behavior / UI
   disabled?: boolean;
   onFocusScroll?: React.FocusEventHandler<HTMLInputElement>;
   className?: string;
+
+  mode?: SetListMode;
 
   // Optional helper note under header
   note?: string;
@@ -37,6 +40,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
   onChange,
   onRemove,
   onAdd,
+  onToggleDone,
   onDeleteExercise,
   deleteDisabled,
   disabled = false,
@@ -47,6 +51,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
   onPrimary,
   primaryLabel = "Save",
   primaryDisabled = false,
+  mode = "edit",
 }) => {
   return (
     <div className={["rounded-2xl bg-card/70 border border-border p-3 md:p-4", className].join(" ")}
@@ -59,19 +64,20 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
 
       {/* The unified set editor UI */}
       <SetList
-        mode="edit"
+        mode={mode}
         items={items}
-        onDeleteExercise={onDeleteExercise}
+        onDeleteExercise={mode === "workout" ? undefined : onDeleteExercise}
         deleteDisabled={deleteDisabled}
         onChange={onChange}
-        onRemove={onRemove}
+        onRemove={mode === "workout" ? undefined : onRemove}
         onAdd={onAdd}
+        onToggleDone={onToggleDone}
         onFocusScroll={onFocusScroll}
         disabled={disabled}
       />
 
       {/* Secondary row (trash/cancel) */}
-      {onCancel && (
+      {mode !== "workout" && onCancel && (
         <div className="mt-4 flex justify-end items-center gap-2">
           <TactileButton
             variant="secondary"
@@ -89,7 +95,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
       )}
 
       {/* Primary CTA (optional) */}
-      {onPrimary && (
+      {mode !== "workout" && onPrimary && (
         <div className="mt-6">
           <TactileButton
             onClick={onPrimary}

--- a/test/utils/test-user.ts
+++ b/test/utils/test-user.ts
@@ -1,8 +1,9 @@
 /**
  * Test User Management Utilities
- * 
+ *
  * Handles creation, management, and cleanup of test users
  */
+import { logger } from "../../utils/logging";
 
 export interface TestUser {
   email: string;


### PR DESCRIPTION
## Summary
- scaffold workout mode on ExerciseSetupScreen with start/end buttons and done tracking
- extend SetList and ExerciseSetEditorCard to support workout mode with completion checkboxes
- add Supabase workout flow API stubs
- persist workout data only when ending a session, applying template updates via journal
- define missing `onToggleDone` prop in SetList to prevent startup error

## Testing
- `npm test` *(fails: Real Authentication Integration Tests – expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_68b73b9e4008832191980a65067dc5f4