### PR TITLE
Persist workout mode after adding exercises

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,6 +28,8 @@ function AppContent() {
     selectedExercisesForSetup,
     setSelectedExercisesForSetup,
     routineAccess,
+    exerciseSetupMode,
+    setExerciseSetupMode,
     handleAuthSuccess,
     navigateToSignUp,
     navigateToSignIn,
@@ -88,6 +90,8 @@ function AppContent() {
           onExerciseSelected={handleExercisesSelected}
           onCloseExerciseSetup={closeExerciseSetup}
           onExerciseSetupComplete={handleExerciseSetupComplete}
+          exerciseSetupMode={exerciseSetupMode}
+          setExerciseSetupMode={setExerciseSetupMode}
           onSelectRoutine={onRoutineSelection}
           onCloseExerciseSetupToRoutines={closeExerciseSetupToRoutines}
           bottomBar={bottomBarEl}

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -19,6 +19,9 @@ interface AppRouterProps {
   currentRoutineName: string;
   routineAccess: RoutineAccess;
 
+  exerciseSetupMode: "plan" | "workout";
+  setExerciseSetupMode: (mode: "plan" | "workout") => void;
+
   selectedExercisesForSetup: Exercise[];
   setSelectedExercisesForSetup: (exercises: Exercise[]) => void;
 
@@ -52,6 +55,9 @@ export function AppRouter({
   currentRoutineId,
   currentRoutineName,
   routineAccess,
+
+  exerciseSetupMode,
+  setExerciseSetupMode,
 
   selectedExercisesForSetup,
   setSelectedExercisesForSetup,
@@ -144,6 +150,8 @@ export function AppRouter({
             onShowExerciseSelector={onCloseExerciseSetup}
             access={routineAccess}
             bottomBar={bottomBar}
+            initialMode={exerciseSetupMode}
+            onModeChange={setExerciseSetupMode}
           />
         )}
 

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -79,6 +79,8 @@ interface ExerciseSetupScreenProps {
   onShowExerciseSelector?: () => void;
   access?: RoutineAccess;
   bottomBar?: React.ReactNode;
+  initialMode?: "plan" | "workout";
+  onModeChange?: (mode: "plan" | "workout") => void;
 }
 
 /* =======================================================================================
@@ -96,6 +98,9 @@ export function ExerciseSetupScreen({
   isEditingExistingRoutine = false,
   onShowExerciseSelector,
   access = RoutineAccess.Editable,
+  bottomBar,
+  initialMode = "plan",
+  onModeChange,
 }: ExerciseSetupScreenProps) {
   const { userToken } = useAuth();
 
@@ -106,7 +111,7 @@ export function ExerciseSetupScreen({
   const [loadingSets, setLoadingSets] = useState<Record<string, boolean>>({}); // key by exercise id as string
 
   type ScreenMode = "plan" | "workout";
-  const [screenMode, setScreenMode] = useState<ScreenMode>("plan");
+  const [screenMode, setScreenMode] = useState<ScreenMode>(initialMode);
   const inWorkout = screenMode === "workout";
 
   // Append-only action journal (doesn't trigger re-renders)
@@ -437,6 +442,11 @@ export function ExerciseSetupScreen({
     });
   };
 
+  const updateMode = (mode: ScreenMode) => {
+    setScreenMode(mode);
+    onModeChange?.(mode);
+  };
+
   const startWorkout = () => {
     // reset any stale journal entries and mark all sets as not done locally
     journalRef.current = makeJournal();
@@ -446,7 +456,7 @@ export function ExerciseSetupScreen({
         sets: ex.sets.map((s) => ({ ...s, done: false })),
       }))
     );
-    setScreenMode("workout");
+    updateMode("workout");
   };
 
   const endWorkout = async () => {
@@ -490,7 +500,7 @@ export function ExerciseSetupScreen({
 
       await reloadFromDb();
       toast.success("Workout saved!");
-      setScreenMode("plan");
+      updateMode("plan");
     } catch (e) {
       logger.error(String(e));
       toast.error("Failed to save workout");

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -21,6 +21,11 @@ export function useAppNavigation() {
   const [selectedExercisesForSetup, setSelectedExercisesForSetup] = useState<Exercise[]>([]);
   const [routineAccess, setRoutineAccess] = useState<RoutineAccess>(RoutineAccess.Editable);
 
+  // Persist ExerciseSetupScreen mode ("plan" or "workout") across navigation
+  const [exerciseSetupMode, setExerciseSetupMode] = useState<"plan" | "workout">(
+    "plan"
+  );
+
 
   const handleUnauthorizedError = (error: Error) => {
     if (error.message === "UNAUTHORIZED") {
@@ -63,6 +68,7 @@ export function useAppNavigation() {
     if (routineId) setCurrentRoutineId(routineId);
     setSelectedExercisesForSetup([]); // start empty
     setRoutineAccess(RoutineAccess.Editable);
+    setExerciseSetupMode("plan");
     setCurrentView("exercise-setup");
   };
 
@@ -82,6 +88,7 @@ export function useAppNavigation() {
     setCurrentRoutineId(null);
     setCurrentRoutineName("");
     setSelectedExercisesForSetup([]);
+    setExerciseSetupMode("plan");
     setCurrentView("workouts");
   };
 
@@ -96,7 +103,9 @@ export function useAppNavigation() {
     setCurrentRoutineName(routineName);
     setSelectedExercisesForSetup([]);
     setRoutineAccess(access || RoutineAccess.Editable);
-    setCurrentView("exercise-setup");  };
+    setExerciseSetupMode("plan");
+    setCurrentView("exercise-setup");
+  };
 
 
   const closeCreateRoutine = () => setCurrentView("workouts");
@@ -105,6 +114,7 @@ export function useAppNavigation() {
     setCurrentRoutineId(null);
     setCurrentRoutineName("");
     setSelectedExercisesForSetup([]);
+    setExerciseSetupMode("plan");
     setCurrentView("workouts");
     setRefreshTrigger(prev => prev + 1);
   };
@@ -132,6 +142,8 @@ export function useAppNavigation() {
     setSelectedExercisesForSetup,
     routineAccess,
     setRoutineAccess,
+    exerciseSetupMode,
+    setExerciseSetupMode,
 
     handleAuthSuccess,
     navigateToSignUp,


### PR DESCRIPTION
## Summary
- Preserve ExerciseSetup screen mode across navigation so workouts stay in progress
- Pass mode through navigation layer and update when starting or ending workouts

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b74b2fddc08321994f6b8dcc5d018c