### PR TITLE
Refine bottom navigation styling

### DIFF
--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -1,11 +1,7 @@
 import type { LucideIcon } from "lucide-react";
-import { TrendingUp, Dumbbell, User } from "lucide-react";
-import { TactileButton } from "./TactileButton";
+import { Dumbbell, TrendingUp, User } from "lucide-react";
 
 export type TabType = "workouts" | "progress" | "profile";
-
-// Match TactileButton's allowed variants (from your error message)
-type ButtonVariant = "primary" | "secondary" | "sage" | "peach" | "mint";
 
 interface BottomNavigationProps {
   activeTab: TabType;
@@ -13,38 +9,39 @@ interface BottomNavigationProps {
 }
 
 export function BottomNavigation({ activeTab, onTabChange }: BottomNavigationProps) {
-  const tabs: Array<{
-    id: TabType;
-    label: string;
-    icon: LucideIcon;
-    activeVariant: ButtonVariant;
-  }> = [
-    { id: "workouts", label: "Workouts", icon: Dumbbell,  activeVariant: "primary" },
-    { id: "progress", label: "Progress", icon: TrendingUp, activeVariant: "sage"    },
-    { id: "profile",  label: "Profile",  icon: User,       activeVariant: "peach"   },
+  const tabs: Array<{ id: TabType; label: string; icon: LucideIcon }> = [
+    { id: "workouts", label: "Workouts", icon: Dumbbell },
+    { id: "progress", label: "Progress", icon: TrendingUp },
+    { id: "profile", label: "Profile", icon: User },
   ];
 
   return (
     <nav aria-label="Bottom navigation" className="w-full">
-      <div className="flex justify-center gap-2">
+      <ul className="flex justify-around">
         {tabs.map((tab) => {
-          const variant: ButtonVariant =
-            activeTab === tab.id ? tab.activeVariant : "secondary";
-
+          const isActive = activeTab === tab.id;
           return (
-            <TactileButton
-              key={tab.id}
-              variant={variant}
-              size="md"
-              className={`flex-1 flex flex-col items-center gap-1 py-2 ${activeTab === tab.id ? "" : "shadow-sm"}`}
-              onClick={() => onTabChange(tab.id)}
-            >
-              <tab.icon size={14} />
-              <span className="text-xs">{tab.label}</span>
-            </TactileButton>
+            <li key={tab.id} className="flex-1">
+              <button
+                onClick={() => onTabChange(tab.id)}
+                className="w-full flex flex-col items-center gap-1 py-2 text-xs"
+                aria-current={isActive ? "page" : undefined}
+              >
+                <tab.icon
+                  size={20}
+                  className={isActive ? "text-warm-brown" : "text-warm-brown/50"}
+                />
+                <span
+                  className={isActive ? "font-medium text-warm-brown" : "text-warm-brown/50"}
+                >
+                  {tab.label}
+                </span>
+              </button>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </nav>
   );
 }
+

--- a/components/layouts/AppScreen.tsx
+++ b/components/layouts/AppScreen.tsx
@@ -206,7 +206,7 @@ export default function AppScreen({
           }}
         >
           <div
-            className={cx(innerWidthClasses, padBottomBar && "px-4 pt-4")}
+            className={cx(innerWidthClasses, padBottomBar && "px-4 py-2")}
             style={innerWidthStyle}
           >
             {bottomBar}


### PR DESCRIPTION
## Summary
- Simplify bottom navigation to icon and label tabs with active color states
- Slim down global bottom bar padding for a shorter navigation height

## Testing
- `npm test` (fails: Real Authentication Integration Tests)
- `npx tsc --noEmit` (fails: capacitor.config.ts, AppRouter.tsx, CircularProgress.tsx, AddExercisesToRoutineScreen.tsx, ExerciseSetupScreen.tsx, ProfileScreen.tsx, ProgressScreen.tsx, safe-area.ts)


------
https://chatgpt.com/codex/tasks/task_e_68b777b7a8d083218c7ec986b0de4d0c