### PR TITLE
Standardize bottom navigation height across screens

### DIFF
--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React from "react";
 import type { LucideIcon } from "lucide-react";
 import { Dumbbell, TrendingUp, User } from "lucide-react";
 
@@ -40,10 +40,23 @@ export function BottomNavigation({
 
   // Render custom content when provided
   if (children) {
+    const enhancedChildren = React.Children.map(children, (child) => {
+      if (React.isValidElement(child)) {
+        const existing = (child.props as { className?: string }).className ?? "";
+        return React.cloneElement(child, {
+          className: `${existing} h-14`.trim(),
+        });
+      }
+      return child;
+    });
+
     return (
-      <nav aria-label="Bottom navigation" className={`w-full ${className}`}>
+      <nav
+        aria-label="Bottom navigation"
+        className={`w-full h-14 flex items-center justify-center ${className}`}
+      >
         <div className="flex w-full items-center justify-center gap-3">
-          {children}
+          {enhancedChildren}
         </div>
       </nav>
     );
@@ -51,8 +64,11 @@ export function BottomNavigation({
 
   // Fallback to tab navigation
   return (
-    <nav aria-label="Bottom navigation" className={`w-full ${className}`}>
-      <ul className="flex justify-around">
+    <nav
+      aria-label="Bottom navigation"
+      className={`w-full h-14 flex items-center justify-center ${className}`}
+    >
+      <ul className="w-full flex justify-around">
         {tabs.map((tab) => {
           const isActive = activeTab === tab.id;
           return (

--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -290,7 +290,7 @@ export function AddExercisesToRoutineScreen({
           <TactileButton
             onClick={handleAddExercise}
             disabled={selectedExercises.length === 0 || isAddingExercise}
-            className={`h-12 md:h-14 sm:w-auto px-6 md:px-8 font-medium border-0 transition-all ${
+            className={`sm:w-auto px-6 md:px-8 font-medium border-0 transition-all ${
               selectedExercises.length > 0
                 ? "bg-primary hover:bg-primary-hover text-primary-foreground opacity-90 btn-tactile"
                 : "bg-warm-brown/20 text-warm-brown/40 cursor-not-allowed"

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -682,7 +682,7 @@ export function ExerciseSetupScreen({
                 variant="secondary"
                 onClick={onCancelAll}
                 disabled={access === RoutineAccess.ReadOnly}
-                className={`flex-1 h-11 md:h-12 ${
+                className={`flex-1 ${
                   access === RoutineAccess.ReadOnly
                     ? "opacity-50 cursor-not-allowed bg-gray-100 text-gray-400 border-gray-200"
                     : "bg-transparent border-warm-brown/20 text-warm-brown/60 hover:bg-soft-gray"
@@ -693,7 +693,7 @@ export function ExerciseSetupScreen({
               <TactileButton
                 onClick={onSaveAll}
                 disabled={savingAll || access === RoutineAccess.ReadOnly}
-                className={`flex-1 h-11 md:h-12 font-medium border-0 transition-all ${
+                className={`flex-1 font-medium border-0 transition-all ${
                   access === RoutineAccess.ReadOnly
                     ? "opacity-50 cursor-not-allowed bg-gray-400"
                     : "bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
@@ -709,7 +709,7 @@ export function ExerciseSetupScreen({
         <BottomNavigation>
           <TactileButton
             onClick={startWorkout}
-            className="h-11 md:h-12 px-6 md:px-8 font-medium border-0 transition-all bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
+            className="px-6 md:px-8 font-medium border-0 transition-all bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
           >
             START WORKOUT
           </TactileButton>
@@ -721,7 +721,7 @@ export function ExerciseSetupScreen({
         <TactileButton
           onClick={endWorkout}
           disabled={savingWorkout}
-          className="h-11 md:h-12 px-6 md:px-8 font-medium border-0 transition-all bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
+          className="px-6 md:px-8 font-medium border-0 transition-all bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
         >
           {savingWorkout ? "SAVING..." : "END WORKOUT"}
         </TactileButton>


### PR DESCRIPTION
## Summary
- Auto-apply standard height to custom bottom navigation buttons
- Remove manual height classes from AddExercisesToRoutine and ExerciseSetup screens

## Testing
- `npm test` *(fails: Real Authentication Integration Tests – expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_68b828cdb7e88321ab6068d0eece258f