### PR TITLE
Add dark mode toggle and unify theme tokens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,8 +5,7 @@ import { useAuthEffects } from "./hooks/useAuthEffects";
 import { useAppNavigation } from "./hooks/useAppNavigation";
 import { useMobileSetup } from "./hooks/useMobileSetup";
 import { Toaster } from "./components/ui/sonner";
-import { useState } from "react";
-import ThemeToggle from "./components/ThemeToggle";
+import { useState, useEffect } from "react";
 
 import { BottomNavigation, TabType } from "./components/BottomNavigation";
 import { VIEWS_WITHOUT_BOTTOM_NAV } from "./utils/navigation";
@@ -48,6 +47,13 @@ function AppContent() {
   // ⬅️ now includes authReady
   const { isAuthenticated, authReady } = useAuthEffects({ currentView, setCurrentView });
 
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark");
+    }
+  }, []);
+
   const showBottomNav = !VIEWS_WITHOUT_BOTTOM_NAV.includes(currentView);
   const [overlayOpen, setOverlayOpen] = useState(false);
 
@@ -70,7 +76,6 @@ function AppContent() {
 
   return (
     <div id="app" className="relative h-dvh flex flex-col overflow-hidden">
-      <ThemeToggle className="absolute top-2 right-2" />
       <main className="flex-1 min-h-0 overflow-hidden">
         <AppRouter
           currentView={currentView}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -6,16 +6,21 @@ interface ThemeToggleProps {
 }
 
 export function ThemeToggle({ className }: ThemeToggleProps) {
-  const [isDark, setIsDark] = useState(() =>
-    typeof window !== "undefined" && document.documentElement.classList.contains("dark")
-  );
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const stored = localStorage.getItem("theme");
+    if (stored) return stored === "dark";
+    return document.documentElement.classList.contains("dark");
+  });
 
   useEffect(() => {
     const root = document.documentElement;
     if (isDark) {
       root.classList.add("dark");
+      localStorage.setItem("theme", "dark");
     } else {
       root.classList.remove("dark");
+      localStorage.setItem("theme", "light");
     }
     window.dispatchEvent(new CustomEvent("themechange", { detail: { isDark } }));
   }, [isDark]);

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -684,7 +684,7 @@ export function ExerciseSetupScreen({
                 disabled={access === RoutineAccess.ReadOnly}
                 className={`flex-1 ${
                   access === RoutineAccess.ReadOnly
-                    ? "opacity-50 cursor-not-allowed bg-gray-100 text-gray-400 border-gray-200"
+                    ? "opacity-50 cursor-not-allowed bg-muted text-muted-foreground border-border"
                     : "bg-transparent border-warm-brown/20 text-warm-brown/60 hover:bg-soft-gray"
                 } font-medium`}
               >
@@ -695,7 +695,7 @@ export function ExerciseSetupScreen({
                 disabled={savingAll || access === RoutineAccess.ReadOnly}
                 className={`flex-1 font-medium border-0 transition-all ${
                   access === RoutineAccess.ReadOnly
-                    ? "opacity-50 cursor-not-allowed bg-gray-400"
+                    ? "opacity-50 cursor-not-allowed bg-muted text-muted-foreground"
                     : "bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
                 }`}
               >

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -19,6 +19,7 @@ import { supabaseAPI, Profile } from "../../utils/supabase/supabase-api";
 import { toast } from "sonner";
 import { AppScreen, Section, ScreenHeader, Stack } from "../layouts";
 import { logger, getLogLevel, setLogLevel, getAvailableLogLevels, type LogLevel } from "../../utils/logging";
+import SettingsSheet from "../sheets/SettingsSheet";
 
 interface PersonalBest {
   exercise: string;
@@ -37,6 +38,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const personalBests: PersonalBest[] = [
     { exercise: "Bench Press", weight: 225, reps: 5, date: "2 weeks ago" },
@@ -270,6 +272,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
             <TactileButton
               variant="secondary"
               className="w-full flex items-center justify-center gap-2"
+              onClick={() => setSettingsOpen(true)}
             >
               <Settings size={16} />
               Settings
@@ -305,6 +308,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           </Card>
         </Section>
       </Stack>
+      <SettingsSheet open={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </AppScreen>
   );
 }

--- a/components/sheets/RoutineActionsSheets.tsx
+++ b/components/sheets/RoutineActionsSheets.tsx
@@ -35,7 +35,7 @@ export default function RoutineActionsSheet({
 
   const header = (
     <div>
-      <p className="text-xs text-gray-500">Routine</p>
+      <p className="text-xs text-muted-foreground">Routine</p>
       <h3 className="font-medium text-warm-brown truncate text-[clamp(14px,3.8vw,18px)]">
         {routineName}
       </h3>
@@ -55,7 +55,7 @@ export default function RoutineActionsSheet({
         <>
           <div>
             <button
-              className="w-full text-left px-4 py-4 hover:bg-gray-50"
+              className="w-full text-left px-4 py-4 hover:bg-soft-gray/50"
               onClick={() => setMode("renaming")}
             >
               Rename
@@ -78,7 +78,7 @@ export default function RoutineActionsSheet({
       {/* RENAMING */}
       {mode === "renaming" && (
         <div className="p-4 space-y-3">
-          <label className="text-sm text-gray-600">New name</label>
+          <label className="text-sm text-muted-foreground">New name</label>
           <input
             autoFocus
             value={renameValue}
@@ -120,10 +120,10 @@ export default function RoutineActionsSheet({
       {/* CONFIRM DELETE */}
       {mode === "confirmDelete" && (
         <div className="p-4 space-y-3">
-          <p className="text-sm text-gray-700">
+          <p className="text-sm text-foreground">
             Delete <span className="font-medium">{routineName}</span>?
             <br />
-            <span className="text-gray-500">This will remove it from your list</span>
+            <span className="text-muted-foreground">This will remove it from your list</span>
           </p>
           <div className="flex gap-3 pt-1">
             <TactileButton

--- a/components/sheets/SettingsSheet.tsx
+++ b/components/sheets/SettingsSheet.tsx
@@ -1,0 +1,26 @@
+// components/sheets/SettingsSheet.tsx
+import * as React from "react";
+import BottomSheet from "./BottomSheets";
+import ThemeToggle from "../ThemeToggle";
+
+interface SettingsSheetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function SettingsSheet({ open, onClose }: SettingsSheetProps) {
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      header={<h3 className="font-medium text-foreground">Settings</h3>}
+    >
+      <div className="p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <span className="text-foreground">Dark Mode</span>
+          <ThemeToggle />
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#e07a5f" />
+    <script>
+      const t = localStorage.getItem('theme');
+      if (t === 'dark') document.documentElement.classList.add('dark');
+    </script>
     <meta name="description" content="Track your workouts with a beautiful, intuitive interface" />
     
     <!-- iOS specific meta tags -->
@@ -30,7 +34,7 @@
         margin: 0;
         padding: 0;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-        background-color: #fefcfb;
+        background-color: var(--background);
         overflow-x: hidden;
       }
       
@@ -47,8 +51,8 @@
         transform: translate(-50%, -50%);
         width: 40px;
         height: 40px;
-        border: 3px solid #f4e8c1;
-        border-top: 3px solid #e07a5f;
+        border: 3px solid var(--secondary);
+        border-top: 3px solid var(--primary);
         border-radius: 50%;
         animation: spin 1s linear infinite;
       }


### PR DESCRIPTION
## Summary
- introduce settings sheet with dark mode toggle and persistent theme preference
- remove hardcoded gray colors for dark-mode friendly tokens
- use CSS variables for initial page styling and apply saved theme on load

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b82d9f688083219ff4d302f5c210e4