### PR TITLE
Add BottomNavigationButton for consistent action bar sizing

### DIFF
--- a/components/BottomNavigation.tsx
+++ b/components/BottomNavigation.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Dumbbell, TrendingUp, User } from "lucide-react";
 
@@ -20,7 +20,7 @@ interface BottomNavigationProps {
    * children are rendered instead, allowing the component to act
    * as a generic bottom action bar.
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
 
   /** Additional classes on the root container */
   className?: string;
@@ -40,23 +40,13 @@ export function BottomNavigation({
 
   // Render custom content when provided
   if (children) {
-    const enhancedChildren = React.Children.map(children, (child) => {
-      if (React.isValidElement(child)) {
-        const existing = (child.props as { className?: string }).className ?? "";
-        return React.cloneElement(child, {
-          className: `${existing} h-14`.trim(),
-        });
-      }
-      return child;
-    });
-
     return (
       <nav
         aria-label="Bottom navigation"
         className={`w-full h-14 flex items-center justify-center ${className}`}
       >
         <div className="flex w-full items-center justify-center gap-3">
-          {enhancedChildren}
+          {children}
         </div>
       </nav>
     );

--- a/components/BottomNavigationButton.tsx
+++ b/components/BottomNavigationButton.tsx
@@ -1,0 +1,26 @@
+import { TactileButton } from "./TactileButton";
+import { ButtonHTMLAttributes, ReactNode } from "react";
+
+interface BottomNavigationButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode;
+  variant?: "primary" | "secondary" | "sage" | "peach" | "mint";
+  className?: string;
+}
+
+export function BottomNavigationButton({
+  children,
+  variant = "primary",
+  className,
+  ...props
+}: BottomNavigationButtonProps) {
+  return (
+    <TactileButton
+      variant={variant}
+      size="sm"
+      className={className}
+      {...props}
+    >
+      {children}
+    </TactileButton>
+  );
+}

--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useMemo, memo } from "react";
 import { Search } from "lucide-react";
 import { Input } from "../ui/input";
-import { TactileButton } from "../TactileButton";
+import { BottomNavigationButton } from "../BottomNavigationButton";
 import SegmentedToggle from "../segmented/SegmentedToggle";
 import { supabaseAPI, Exercise } from "../../utils/supabase/supabase-api";
 import { useAuth } from "../AuthContext";
@@ -287,7 +287,7 @@ export function AddExercisesToRoutineScreen({
       showBottomBarBorder={false}
       bottomBar={
         <BottomNavigation>
-          <TactileButton
+          <BottomNavigationButton
             onClick={handleAddExercise}
             disabled={selectedExercises.length === 0 || isAddingExercise}
             className={`sm:w-auto px-6 md:px-8 font-medium border-0 transition-all ${
@@ -301,7 +301,7 @@ export function AddExercisesToRoutineScreen({
               : selectedExercises.length > 0
               ? `ADD (${selectedExercises.length})`
               : "ADD"}
-          </TactileButton>
+          </BottomNavigationButton>
         </BottomNavigation>
       }
       bottomBarSticky

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AppScreen, Section, ScreenHeader, Stack, Spacer } from "../layouts";
 import { BottomNavigation } from "../BottomNavigation";
-import { TactileButton } from "../TactileButton";
+import { BottomNavigationButton } from "../BottomNavigationButton";
 import ExpandingCard from "../ui/ExpandingCard";
 import ExerciseSetEditorCard from "../sets/ExerciseSetEditorCard";
 import { RoutineAccess } from "../../hooks/useAppNavigation";
@@ -678,7 +678,7 @@ export function ExerciseSetupScreen({
         return (
           <BottomNavigation>
             <div className="flex w-full gap-3">
-              <TactileButton
+              <BottomNavigationButton
                 variant="secondary"
                 onClick={onCancelAll}
                 disabled={access === RoutineAccess.ReadOnly}
@@ -689,8 +689,8 @@ export function ExerciseSetupScreen({
                 } font-medium`}
               >
                 CANCEL ALL
-              </TactileButton>
-              <TactileButton
+              </BottomNavigationButton>
+              <BottomNavigationButton
                 onClick={onSaveAll}
                 disabled={savingAll || access === RoutineAccess.ReadOnly}
                 className={`flex-1 font-medium border-0 transition-all ${
@@ -700,31 +700,31 @@ export function ExerciseSetupScreen({
                 }`}
               >
                 {savingAll ? "SAVING..." : `SAVE ALL`}
-              </TactileButton>
+              </BottomNavigationButton>
             </div>
           </BottomNavigation>
         );
       }
       return (
         <BottomNavigation>
-          <TactileButton
+          <BottomNavigationButton
             onClick={startWorkout}
             className="px-6 md:px-8 font-medium border-0 transition-all bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
           >
             START WORKOUT
-          </TactileButton>
+          </BottomNavigationButton>
         </BottomNavigation>
       );
     }
     return (
       <BottomNavigation>
-        <TactileButton
+        <BottomNavigationButton
           onClick={endWorkout}
           disabled={savingWorkout}
           className="px-6 md:px-8 font-medium border-0 transition-all bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
         >
           {savingWorkout ? "SAVING..." : "END WORKOUT"}
-        </TactileButton>
+        </BottomNavigationButton>
       </BottomNavigation>
     );
   };


### PR DESCRIPTION
## Summary
- add reusable BottomNavigationButton wrapping TactileButton
- use BottomNavigationButton in ExerciseSetup and AddExercises screens for uniform height
- refine button spacing so bottom bar actions include vertical padding

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b84f395a48832186a130266f9116b2