### PR TITLE
feat: unify routine and exercise list items

### DIFF
--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { AppScreen, ScreenHeader, Section, Stack, Spacer } from "../layouts";
 import { BottomNavigation } from "../BottomNavigation";
 import { logger } from "../../utils/logging";
+import ListItem from "../ui/ListItem";
 
 interface AddExercisesToRoutineScreenProps {
   routineId?: number;
@@ -66,32 +67,25 @@ const ExerciseRow = memo(function ExerciseRow({
       onClick={() => onSelect(exercise)}
       className="w-full text-left focus:outline-none"
     >
-      <div
+      <ListItem
+        leading={<span className="text-sm md:text-base font-medium text-warm-brown/60">{initials}</span>}
+        leadingClassName="w-10 h-10 md:w-12 md:h-12 bg-warm-brown/10 rounded-lg grid place-items-center"
+        primary={exercise.name}
+        secondary={subtitle}
+        primaryClassName="font-medium text-warm-brown"
+        secondaryClassName="text-xs md:text-sm text-warm-brown/60"
         className={[
-          "p-3 md:p-4 rounded-xl border transition-all",
+          "rounded-xl border transition-all px-3 md:px-4",
           selected
-            // toned down selection (less “bright orange”)
             ? "bg-warm-coral/60 border-warm-coral/30 shadow-md"
             : "bg-card border-border hover:bg-soft-gray/50 hover:border-warm-coral/30 hover:shadow-md",
         ].join(" ")}
-      >
-        <div className="flex items-center gap-3 md:gap-4">
-          <div className="w-10 h-10 md:w-12 md:h-12 bg-warm-brown/10 rounded-lg grid place-items-center">
-            <span className="text-sm md:text-base font-medium text-warm-brown/60">
-              {initials}
-            </span>
-          </div>
-          <div className="flex-1 min-w-0">
-            <h3 className="font-medium text-warm-brown truncate">{exercise.name}</h3>
-            <p className="text-xs md:text-sm text-warm-brown/60 truncate">{subtitle}</p>
-          </div>
+        trailing={
           <div className="text-warm-brown/40">
-            <div className="w-6 h-6 rounded-full border border-warm-brown/20 grid place-items-center">
-              <div>ⓘ</div>
-            </div>
+            <div className="w-6 h-6 rounded-full border border-warm-brown/20 grid place-items-center">ⓘ</div>
           </div>
-        </div>
-      </div>
+        }
+      />
     </button>
   );
 });

--- a/components/screens/WorkoutDashboardScreen.tsx
+++ b/components/screens/WorkoutDashboardScreen.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { TactileButton } from "../TactileButton";
-import { MoreVertical, AlertCircle, Clock3 as Clock, TrendingUp } from "lucide-react";
+import { AlertCircle, Clock3 as Clock, TrendingUp } from "lucide-react";
 import { useStepTracking } from "../../hooks/useStepTracking";
 import { supabaseAPI, UserRoutine } from "../../utils/supabase/supabase-api";
 import { useAuth } from "../AuthContext";
@@ -13,6 +13,7 @@ import { RoutineAccess } from "../../hooks/useAppNavigation";
 import { logger } from "../../utils/logging";
 import { performanceTimer } from "../../utils/performanceTimer";
 import { loadRoutineExercisesWithSets } from "../../utils/routineLoader";
+import ListItem from "../ui/ListItem";
 
 interface WorkoutDashboardScreenProps {
   onCreateRoutine: () => void;
@@ -331,69 +332,36 @@ export default function WorkoutDashboardScreen({
                             view === RoutinesView.My ? RoutineAccess.Editable : RoutineAccess.ReadOnly
                           )
                         }
-                        className="
-                          w-full
-                          rounded-2xl border border-border
-                          bg-card shadow-sm hover:shadow-md transition-all
-                          p-4
-                          text-left
-                        "
+                        className="w-full rounded-2xl border border-border bg-card shadow-sm hover:shadow-md transition-all text-left"
                       >
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="flex items-center gap-3 min-w-0">
-                            <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${palette.bg}`}>
-                              <div className={`w-8 h-8 ${palette.iconBg} rounded-lg grid place-items-center text-primary-foreground text-lg`}>
-                                <span>{palette.emoji}</span>
-                              </div>
+                        <ListItem
+                          leading={
+                            <div className={`w-8 h-8 ${palette.iconBg} rounded-lg grid place-items-center text-primary-foreground text-lg`}>
+                              <span>{palette.emoji}</span>
                             </div>
-
-                            <div className="min-w-0">
-                              <h3
-                                className="
-                                  font-medium text-warm-brown truncate 
-                                  text-[clamp(16px,4.5vw,19px)] 
-                                  text-left 
-                                "
-                              >
-                                {routine.name}
-                              </h3>
-
-                              <p className="text-[clamp(11px,3.2vw,12px)] text-warm-brown/60 truncate text-left">
-                                {muscleGroups}
-                              </p>
-
-                              <div className="
-                                mt-2 flex items-center gap-4 
-                                text-[clamp(11px,3.2vw,12px)] 
-                                text-warm-brown/70">
-                                <span className="inline-flex items-center gap-1">
-                                  <Clock size={14} />
-                                  {loadingCounts ? "—" : timeMin !== null ? `${timeMin} min` : "—"}
-                                </span>
-                                <span className="inline-flex items-center gap-1">
-                                  <TrendingUp size={14} />
-                                  {loadingCounts ? "—" : `${exerciseCount} exercise${exerciseCount === 1 ? "" : "s"}`}
-                                </span>
-                              </div>
+                          }
+                          leadingClassName={`w-12 h-12 rounded-xl flex items-center justify-center ${palette.bg}`}
+                          primary={routine.name}
+                          secondary={muscleGroups}
+                          tertiary={
+                            <div className="mt-2 flex items-center gap-4 text-warm-brown/70">
+                              <span className="inline-flex items-center gap-1">
+                                <Clock size={14} />
+                                {loadingCounts ? "—" : timeMin !== null ? `${timeMin} min` : "—"}
+                              </span>
+                              <span className="inline-flex items-center gap-1">
+                                <TrendingUp size={14} />
+                                {loadingCounts ? "—" : `${exerciseCount} exercise${exerciseCount === 1 ? "" : "s"}`}
+                              </span>
                             </div>
-                          </div>
-
-                          {/* right: kebab only when editable */}
-                          {canEdit && (
-                            <TactileButton
-                              variant="secondary"
-                              size="sm"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                openActions(routine, e);
-                              }}
-                              className="shrink-0 p-2 h-auto bg-transparent hover:bg=[var(--soft-gray)]/60 text-warm-brown/70"
-                              aria-label="More options"
-                            >
-                              <MoreVertical size={18} />
-                            </TactileButton>
-                          )}
-                        </div>
+                          }
+                          primaryClassName="font-medium text-warm-brown text-[clamp(16px,4.5vw,19px)]"
+                          secondaryClassName="text-[clamp(11px,3.2vw,12px)] text-warm-brown/60"
+                          tertiaryClassName="text-[clamp(11px,3.2vw,12px)]"
+                          className="p-4"
+                          rightIcon={canEdit ? "kebab" : undefined}
+                          onRightIconClick={(e) => openActions(routine, e)}
+                        />
                       </button>
                     );
                   })}

--- a/components/ui/ExpandingCard.tsx
+++ b/components/ui/ExpandingCard.tsx
@@ -1,7 +1,7 @@
 // components/ui/ExpandingCard.tsx
 import * as React from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown } from "lucide-react";
+import ListItem from "./ListItem";
 
 type Variant = "glass" | "solid" | "plain";
 
@@ -78,53 +78,32 @@ export default function ExpandingCard({
         aria-expanded={expanded}
         aria-controls={bodyId}
         className={[
-          "w-full flex items-center gap-3 text-left select-none",
-          headerPadBySize[size],
-          headerClassName,
+          "w-full text-left select-none",
           disabled ? "opacity-60 cursor-default" : "hover:bg-card/3",
         ].join(" ")}
       >
-        {leading && (
-          <div className="w-12 h-12 rounded-xl overflow-hidden bg-card/10 flex items-center justify-center shrink-0">
-            {leading}
-          </div>
-        )}
-
-        <div className="min-w-0 flex-1">
-          <div
-            className={[
-              "truncate font-semibold",
-              variant === "glass" ? "text-primary-foreground opacity-95" : "text-foreground",
-            ].join(" ")}
-          >
-            {title}
-          </div>
-          {subtitle && (
-            <div
-              className={[
-                "truncate text-sm",
-                variant === "glass" ? "text-primary-foreground opacity-60" : "text-muted-foreground",
-              ].join(" ")}
-            >
-              {subtitle}
-            </div>
-          )}
-        </div>
-
-        {trailing}
-
-        {!disableChevron && (
-          <motion.div
-            animate={{ rotate: expanded ? 180 : 0 }}
-            transition={{ type: "spring", stiffness: 300, damping: 24 }}
-            className={[
-              "ml-1",
-              variant === "glass" ? "text-primary-foreground opacity-70" : "text-warm-brown/70",
-            ].join(" ")}
-          >
-            <ChevronDown size={18} />
-          </motion.div>
-        )}
+        <ListItem
+          leading={leading}
+          leadingClassName="w-12 h-12 rounded-xl overflow-hidden bg-card/10 flex items-center justify-center shrink-0"
+          primary={title}
+          secondary={subtitle}
+          primaryClassName={
+            "truncate font-semibold " +
+            (variant === "glass"
+              ? "text-primary-foreground opacity-95"
+              : "text-foreground")
+          }
+          secondaryClassName={
+            "truncate text-sm " +
+            (variant === "glass"
+              ? "text-primary-foreground opacity-60"
+              : "text-muted-foreground")
+          }
+          trailing={trailing}
+          rightIcon={disableChevron ? undefined : "chevron"}
+          rightIconRotated={expanded}
+          className={headerPadBySize[size] + " " + headerClassName}
+        />
       </button>
 
       <AnimatePresence initial={false}>

--- a/components/ui/ListItem.tsx
+++ b/components/ui/ListItem.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { MoreVertical, ChevronDown } from "lucide-react";
+
+interface ListItemProps extends React.HTMLAttributes<HTMLDivElement> {
+  leading?: React.ReactNode;
+  /** Additional classes for the leading container */
+  leadingClassName?: string;
+  primary: React.ReactNode;
+  /** Classes for the primary text (size, color, weight) */
+  primaryClassName?: string;
+  secondary?: React.ReactNode;
+  secondaryClassName?: string;
+  tertiary?: React.ReactNode;
+  tertiaryClassName?: string;
+  /** Optional custom actions rendered before the right icon */
+  trailing?: React.ReactNode;
+  /** Built-in right icon */
+  rightIcon?: "kebab" | "chevron";
+  /** Rotate the chevron 180 degrees when true */
+  rightIconRotated?: boolean;
+  onRightIconClick?: (e: React.MouseEvent) => void;
+}
+
+export default function ListItem({
+  leading,
+  leadingClassName = "w-12 h-12 rounded-xl bg-warm-brown/10 flex items-center justify-center", 
+  primary,
+  primaryClassName = "text-base font-semibold text-warm-brown",
+  secondary,
+  secondaryClassName = "text-sm text-warm-brown/60",
+  tertiary,
+  tertiaryClassName = "text-sm text-warm-brown/60",
+  trailing,
+  rightIcon,
+  rightIconRotated = false,
+  onRightIconClick,
+  className = "",
+  ...rest
+}: ListItemProps) {
+  const hasSub = !!secondary || !!tertiary;
+  const pyClass = hasSub ? "py-4" : "py-3";
+
+  return (
+    <div className={`flex items-center gap-3 ${pyClass} ${className}`} {...rest}>
+      {leading && (
+        <div className={`shrink-0 ${leadingClassName}`}>{leading}</div>
+      )}
+      <div className="flex-1 min-w-0">
+        <div className={`${primaryClassName} truncate`}>{primary}</div>
+        {secondary && (
+          <div className={`${secondaryClassName} truncate`}>{secondary}</div>
+        )}
+        {tertiary && (
+          <div className={`${tertiaryClassName} truncate`}>{tertiary}</div>
+        )}
+      </div>
+      {trailing}
+      {rightIcon && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRightIconClick?.(e);
+          }}
+          className="ml-2 text-warm-brown/70"
+        >
+          {rightIcon === "kebab" ? (
+            <MoreVertical size={18} />
+          ) : (
+            <ChevronDown
+              size={18}
+              className={rightIconRotated ? "transform rotate-180" : ""}
+            />
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add generic ListItem component supporting images, multiple text rows and optional kebab/chevron
- refactor exercise/routine screens to use ListItem
- update ExpandingCard to leverage ListItem for consistent headers

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b862578af48321a41e8f21769e40e0