### PR TITLE
feat: add floating create routine button

### DIFF
--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -241,6 +241,14 @@ export function ExerciseSetupScreen({
     });
   };
 
+  const recomputeExerciseCompletion = (ex: UIExercise) => {
+    const allDone = ex.sets.length > 0 && ex.sets.every((s) => s.done);
+    ex.completed = allDone;
+    if (allDone) {
+      ex.expanded = false;
+    }
+  };
+
   const ensureSetsLoaded = async (ex: UIExercise) => {
     // With eager load this will usually be a no-op; keep for safety.
     if (ex.loaded || !ex.templateId) return;
@@ -377,6 +385,7 @@ export function ExerciseSetupScreen({
       });
 
       recordSetAdd(journalRef.current, exId, newSetId, nextOrder, initialReps, initialWeight);
+      recomputeExerciseCompletion(ex);
     });
   };
 
@@ -446,6 +455,7 @@ export function ExerciseSetupScreen({
           recordSetReorder(journalRef.current, exId, s.id, s.set_order);
         }
       }
+      recomputeExerciseCompletion(ex);
     });
   };
 
@@ -463,11 +473,7 @@ export function ExerciseSetupScreen({
       if (setId == null) return;
       const s = ex.sets.find((st) => st.id === setId);
       if (s) s.done = done;
-      const allDone = ex.sets.every((st) => st.done);
-      ex.completed = allDone;
-      if (allDone) {
-        ex.expanded = false;
-      }
+      recomputeExerciseCompletion(ex);
     });
   };
 

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -62,6 +62,7 @@ type UIExercise = {
   muscle_group?: string;
   loaded: boolean; // sets loaded
   expanded: boolean;
+  completed: boolean;
   sets: UISet[];
 };
 
@@ -185,6 +186,7 @@ export function ExerciseSetupScreen({
           muscle_group: r.muscle_group,
           loaded: true,
           expanded: false,
+          completed: false,
           sets: r.sets,
         }));
         setExercises(uiList);
@@ -311,6 +313,7 @@ export function ExerciseSetupScreen({
         muscle_group: muscle_group || undefined,
         loaded: true,
         expanded: true,
+        completed: false,
         sets: [{ id: initialSetId, set_order: 1, reps: "0", weight: "0", ...(inWorkout ? { done: false } : {}) }],
       },
     ]);
@@ -460,6 +463,9 @@ export function ExerciseSetupScreen({
       if (setId == null) return;
       const s = ex.sets.find((st) => st.id === setId);
       if (s) s.done = done;
+      const allDone = ex.sets.every((st) => st.done);
+      ex.completed = allDone;
+      ex.expanded = !allDone;
     });
   };
 
@@ -475,6 +481,8 @@ export function ExerciseSetupScreen({
       prev.map((ex) => ({
         ...ex,
         sets: ex.sets.map((s) => ({ ...s, done: false })),
+        completed: false,
+        expanded: false,
       }))
     );
     updateMode("workout");
@@ -570,6 +578,7 @@ export function ExerciseSetupScreen({
         muscle_group: r.muscle_group,
         loaded: true,
         expanded: false,
+        completed: false,
         sets: r.sets,
       }));
       setExercises(uiList);
@@ -776,7 +785,7 @@ export function ExerciseSetupScreen({
                 {initials}
               </span>
             }
-          className="bg-card/80 border-border"
+          className={`${ex.completed ? "bg-success-light/40" : "bg-card/80"} border-border`}
           bodyClassName="pt-2"
         >
           {isLoading || !ex.loaded ? (

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -706,6 +706,9 @@ export function ExerciseSetupScreen({
           </BottomNavigation>
         );
       }
+      if (visible.length === 0) {
+        return null;
+      }
       return (
         <BottomNavigation>
           <BottomNavigationButton

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -787,7 +787,7 @@ export function ExerciseSetupScreen({
                 {initials}
               </span>
             }
-          className={`${ex.completed ? "bg-success-light/40" : "bg-card/80"} border-border`}
+          className={`${ex.completed ? "bg-success-light" : "bg-card/80"} border-border`}
           bodyClassName="pt-2"
         >
           {isLoading || !ex.loaded ? (

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -787,7 +787,7 @@ export function ExerciseSetupScreen({
                 {initials}
               </span>
             }
-          className={`${ex.completed ? "bg-success-light" : "bg-card/80"} border-border`}
+          className={`${ex.completed && !ex.expanded ? "bg-success-light" : "bg-card/80"} border-border`}
           bodyClassName="pt-2"
         >
           {isLoading || !ex.loaded ? (

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -465,7 +465,9 @@ export function ExerciseSetupScreen({
       if (s) s.done = done;
       const allDone = ex.sets.every((st) => st.done);
       ex.completed = allDone;
-      ex.expanded = !allDone;
+      if (allDone) {
+        ex.expanded = false;
+      }
     });
   };
 

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -244,9 +244,7 @@ export function ExerciseSetupScreen({
   const recomputeExerciseCompletion = (ex: UIExercise) => {
     const allDone = ex.sets.length > 0 && ex.sets.every((s) => s.done);
     ex.completed = allDone;
-    if (allDone) {
-      ex.expanded = false;
-    }
+    ex.expanded = !allDone;
   };
 
   const ensureSetsLoaded = async (ex: UIExercise) => {

--- a/components/screens/WorkoutDashboardScreen.tsx
+++ b/components/screens/WorkoutDashboardScreen.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { TactileButton } from "../TactileButton";
-import { AlertCircle, Clock3 as Clock, TrendingUp } from "lucide-react";
+import { AlertCircle, Clock3 as Clock, TrendingUp, Plus } from "lucide-react";
 import { useStepTracking } from "../../hooks/useStepTracking";
 import { supabaseAPI, UserRoutine } from "../../utils/supabase/supabase-api";
 import { useAuth } from "../AuthContext";
@@ -248,11 +248,11 @@ export default function WorkoutDashboardScreen({
 
         <Spacer y="xss" />
 
-        {/* top row: view toggle + create */}
+        {/* view toggle */}
         <Section
           variant="plain"
           padding="none"
-          className="flex items-center justify-between gap-3"
+          className="flex items-center justify-center"
         >
           <SegmentedToggle
             value={view}
@@ -267,15 +267,6 @@ export default function WorkoutDashboardScreen({
             variant="filled"
             tone="accent"
           />
-
-          {canEdit && (
-            <TactileButton
-              onClick={onCreateRoutine}
-              className="bg-primary hover:bg-primary-hover text-primary-foreground px-4 py-2 text-sm font-medium rounded-xl"
-            >
-              Create Routine
-            </TactileButton>
-          )}
         </Section>
 
         {/* routines list with Section loading state */}
@@ -394,6 +385,16 @@ export default function WorkoutDashboardScreen({
           />
         )}
       </Stack>
+
+      {canEdit && (
+        <TactileButton
+          onClick={onCreateRoutine}
+          className="fixed z-40 rounded-full shadow-lg right-4 bottom-24 bg-primary hover:bg-primary-hover text-primary-foreground p-4"
+          aria-label="Create routine"
+        >
+          <Plus className="w-6 h-6" />
+        </TactileButton>
+      )}
     </AppScreen>
   );
 }

--- a/components/sets/SetList.tsx
+++ b/components/sets/SetList.tsx
@@ -162,7 +162,7 @@ const SetList: React.FC<SetListProps> = ({
                     type="checkbox"
                     checked={!!it.done}
                     onChange={(e) => onToggleDone?.(it.key, e.target.checked)}
-                    className="w-5 h-5 ml-auto"
+                    className="w-5 h-5 ml-auto rounded-full border-2 border-border accent-success checked:border-success"
                   />
                 </div>
               ) : canRemove ? (

--- a/components/sets/SetList.tsx
+++ b/components/sets/SetList.tsx
@@ -162,7 +162,7 @@ const SetList: React.FC<SetListProps> = ({
                     type="checkbox"
                     checked={!!it.done}
                     onChange={(e) => onToggleDone?.(it.key, e.target.checked)}
-                    className="w-5 h-5 ml-auto rounded-full border-2 border-border accent-success checked:border-success"
+                    className="w-5 h-5 ml-auto rounded-full border-2 border-border text-success accent-success checked:border-success"
                   />
                 </div>
               ) : canRemove ? (


### PR DESCRIPTION
## Summary
- remove inline Create Routine button
- add sticky plus button at bottom right to create routines

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b97c9bb4ac8321973f3a3941bb8717