### PR TITLE
Add workout timer and header subtitle

### DIFF
--- a/components/layouts/ScreenHeader.tsx
+++ b/components/layouts/ScreenHeader.tsx
@@ -5,6 +5,8 @@ import { Plus } from "lucide-react";
 
 type ScreenHeaderProps = {
   title: string;
+  /** optional secondary line beneath title */
+  subtitle?: React.ReactNode;
   onBack?: () => void;
   right?: React.ReactNode;
   onAdd?: () => void;
@@ -20,10 +22,13 @@ type ScreenHeaderProps = {
   contentHeightPx?: number;
   /** customize title styles (size/weight/etc.) */
   titleClassName?: string;
+  /** customize subtitle styles */
+  subtitleClassName?: string;
 };
 
 export default function ScreenHeader({
   title,
+  subtitle,
   onBack,
   right,
   onAdd,
@@ -37,6 +42,7 @@ export default function ScreenHeader({
   padSafeArea = false,
   contentHeightPx = 74,
   titleClassName = "",
+  subtitleClassName = "",
 }: ScreenHeaderProps) {
   const sizeKey = denseSmall ? "compactTiny" : dense ? "compact" : "comfortable";
   const legacy = {
@@ -72,17 +78,30 @@ export default function ScreenHeader({
           {onBack ? <BackButton onClick={onBack} /> : null}
         </div>
 
-        {/* Center: true-centered title */}
-        <h1
-          className={[
-            "absolute left-1/2 -translate-x-1/2 m-0 font-medium leading-none text-warm-brown truncate",
-            "text-[clamp(16px,4.2vw,20px)]", // default
-            titleClassName,                  // ← user overrides last, so it wins
-          ].join(" ")}
+        {/* Center: true-centered title with optional subtitle */}
+        <div
+          className="absolute left-1/2 -translate-x-1/2 flex flex-col items-center m-0"
           style={{ maxWidth: titleMaxWidth }}
         >
-          {title}
-        </h1>
+          <h1
+            className={[
+              "font-medium leading-none text-warm-brown truncate text-[clamp(16px,4.2vw,20px)]",
+              titleClassName,
+            ].join(" ")}
+          >
+            {title}
+          </h1>
+          {subtitle ? (
+            <span
+              className={[
+                "mt-1 text-xs text-warm-brown",
+                subtitleClassName,
+              ].join(" ")}
+            >
+              {subtitle}
+            </span>
+          ) : null}
+        </div>
 
         {/* Right */}
         <div className="ml-auto shrink-0 flex items-center justify-end" style={{ width: reserveRightPx }}>

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -120,6 +120,45 @@ export function ExerciseSetupScreen({
   // Snapshot of last-saved state for change detection
   const savedSnapshotRef = useRef<any[]>([]);
 
+  // Workout timer state
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const workoutStartRef = useRef<number | null>(null);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  const formatHHMMSS = (totalSeconds: number) => {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return [hours, minutes, seconds]
+      .map((v) => v.toString().padStart(2, "0"))
+      .join(":");
+  };
+
+  useEffect(() => {
+    if (inWorkout) {
+      timerRef.current = setInterval(() => {
+        if (workoutStartRef.current != null) {
+          setElapsedSeconds(
+            Math.floor((Date.now() - workoutStartRef.current) / 1000)
+          );
+        }
+      }, 1000);
+    } else {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      workoutStartRef.current = null;
+      setElapsedSeconds(0);
+    }
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [inWorkout]);
+
   /* -------------------------------------------------------------------------------------
      Utilities
      ------------------------------------------------------------------------------------- */
@@ -481,6 +520,8 @@ export function ExerciseSetupScreen({
   };
 
   const startWorkout = () => {
+    workoutStartRef.current = Date.now();
+    setElapsedSeconds(0);
     // reset any stale journal entries and mark all sets as not done locally
     journalRef.current = makeJournal();
     setExercises((prev) =>
@@ -541,6 +582,13 @@ export function ExerciseSetupScreen({
       //TODO: Uncomment this when we have a way to end a workout
       //await supabaseAPI.endWorkout(workout.id);
       logger.info(" [EXERCISE_SETUP] Workout ended for id: " + workout.id);
+      const durationSecs =
+        workoutStartRef.current != null
+          ? Math.floor((Date.now() - workoutStartRef.current) / 1000)
+          : elapsedSeconds;
+      logger.info(
+        " [EXERCISE_SETUP] Workout duration: " + formatHHMMSS(durationSecs)
+      );
 
       // Apply workout edits to the routine template
       const journal = journalRef.current;
@@ -672,6 +720,7 @@ export function ExerciseSetupScreen({
   const renderHeader = () => (
     <ScreenHeader
       title={routineName || "Routine"}
+      subtitle={inWorkout ? formatHHMMSS(elapsedSeconds) : undefined}
       onBack={handleBack}
       {...(access === RoutineAccess.Editable
         ? {


### PR DESCRIPTION
## Summary
- allow ScreenHeader to render an optional subtitle beneath the title
- track workout duration and show it in header while in workout mode
- log workout time when ending a workout

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a8380d2083218228c62d9b36d44d