### PR TITLE
refactor: streamline step tracking cleanup

### DIFF
--- a/components/screens/WorkoutDashboardScreen.tsx
+++ b/components/screens/WorkoutDashboardScreen.tsx
@@ -60,7 +60,7 @@ export default function WorkoutDashboardScreen({
   const [renameLoading, setRenameLoading] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
 
-  const { steps, goal, isLoading: isLoadingSteps } = useStepTracking(true);
+  const { steps, goal, isLoading: isLoadingSteps } = useStepTracking();
 
   const canEdit = view === RoutinesView.My;
 

--- a/hooks/useStepTracking.ts
+++ b/hooks/useStepTracking.ts
@@ -147,7 +147,7 @@ async function readTodayStepsNative(): Promise<number> {
 }
 
 /** Hook */
-export function useStepTracking(isOnDashboard: boolean): UseStepTrackingReturn {
+export function useStepTracking(): UseStepTrackingReturn {
   const [stepData, setStepData] = useState<StepData>({
     steps: 0,
     lastUpdated: 0,
@@ -182,7 +182,7 @@ export function useStepTracking(isOnDashboard: boolean): UseStepTrackingReturn {
   // Read steps from native
   const readStepData = useCallback(
     async (forceRead: boolean = false) => {
-      if (!forceRead && (!isOnDashboard || !isAppInForeground() || !shouldReadStepData())) return;
+      if (!forceRead && (!isAppInForeground() || !shouldReadStepData())) return;
 
       setIsLoading(true);
       lastReadRef.current = Date.now();
@@ -205,7 +205,7 @@ export function useStepTracking(isOnDashboard: boolean): UseStepTrackingReturn {
         setIsLoading(false);
       }
     },
-    [isOnDashboard, isAppInForeground, shouldReadStepData]
+    [isAppInForeground, shouldReadStepData]
   );
 
   // Force refresh (bypass 10-minute rule)
@@ -220,21 +220,15 @@ export function useStepTracking(isOnDashboard: boolean): UseStepTrackingReturn {
 
   // Poll: check conditions every minute, read if 10+ mins passed
   useEffect(() => {
-    if (isOnDashboard && userToken) {
+    if (userToken) {
       readStepData(); // initial
       intervalRef.current = setInterval(() => readStepData(), 60000);
-      return () => {
-        if (intervalRef.current) clearInterval(intervalRef.current);
-      };
     }
-  }, [isOnDashboard, userToken, readStepData]);
 
-  // Cleanup on unmount
-  useEffect(() => {
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, []);
+  }, [userToken, readStepData]);
 
   const progressRaw = stepData.goal > 0 ? (stepData.steps / stepData.goal) * 100 : 0;
   const progressPercentage = Math.min(Math.max(progressRaw, 0), 100);


### PR DESCRIPTION
## Summary
- simplify step tracking hook by consolidating interval cleanup into single effect
- remove unused dashboard flag from step tracking hook and its caller

## Testing
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0a14ed9083219b9b72db52ea45ae