### PR TITLE
Add exercise-level completion checkbox in workout mode

### DIFF
--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -518,6 +518,20 @@ export function ExerciseSetupScreen({
     });
   };
 
+  const onToggleExerciseDone = async (exId: Id, done: boolean) => {
+    const ex = exercises.find((e) => e.id === exId);
+    if (!ex) return;
+    if (!ex.loaded && ex.templateId) {
+      await ensureSetsLoaded(ex);
+    }
+    withExercises((draft) => {
+      const ex = draft.find((d) => d.id === exId);
+      if (!ex) return;
+      ex.sets.forEach((s) => (s.done = done));
+      recomputeExerciseCompletion(ex);
+    });
+  };
+
   const updateMode = (mode: ScreenMode) => {
     setScreenMode(mode);
     onModeChange?.(mode);
@@ -852,11 +866,23 @@ export function ExerciseSetupScreen({
           onToggle={() => toggleExpanded(ex.id)}
           title={ex.name}
           subtitle={subtitle}
-            leading={
-              <span className="text-sm md:text-base font-medium text-warm-brown/60">
-                {initials}
-              </span>
-            }
+          leading={
+            <span className="text-sm md:text-base font-medium text-warm-brown/60">
+              {initials}
+            </span>
+          }
+          trailing={
+            inWorkout ? (
+              <input
+                type="checkbox"
+                checked={ex.completed}
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => void onToggleExerciseDone(ex.id, e.target.checked)}
+                className="w-5 h-5 rounded-full border-2 border-border text-success accent-success checked:border-success"
+              />
+            ) : undefined
+          }
+          disableChevron={inWorkout}
           className={`${ex.completed && !ex.expanded ? "bg-success-light" : "bg-card/80"} border-border`}
           bodyClassName="pt-2"
         >


### PR DESCRIPTION
## Summary
- replace exercise card chevron with a checkbox in workout mode
- allow toggling all sets done for an exercise via new handler

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb203ca25883218b6c35f4a4f38cd4