### PR TITLE
Add measurements editor with radial text speed dial

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,8 +35,10 @@ function AppContent() {
     navigateToSignIn,
     handleTabChange,
     showCreateRoutine,
+    showEditMeasurements,
     handleRoutineCreated,
     closeCreateRoutine,
+    closeEditMeasurements,
     completeRoutineCreation,
     handleExercisesSelected,
     closeExerciseSetup,
@@ -84,8 +86,10 @@ function AppContent() {
           onNavigateToSignUp={navigateToSignUp}
           onNavigateToSignIn={navigateToSignIn}
           onCreateRoutine={showCreateRoutine}
+          onEditMeasurements={showEditMeasurements}
           onRoutineCreated={handleRoutineCreated}
           onCloseCreateRoutine={closeCreateRoutine}
+          onCloseEditMeasurements={closeEditMeasurements}
           onCompleteRoutineCreation={completeRoutineCreation}
           onExerciseSelected={handleExercisesSelected}
           onCloseExerciseSetup={closeExerciseSetup}

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -1,7 +1,8 @@
 import  WorkoutDashboardScreen  from "./screens/WorkoutDashboardScreen";
-import CreateRoutineScreen  from "./screens/CreateRoutineScreen";
-import { AddExercisesToRoutineScreen }  from "./screens/AddExercisesToRoutineScreen";
+import CreateRoutineScreen from "./screens/CreateRoutineScreen";
+import { AddExercisesToRoutineScreen } from "./screens/AddExercisesToRoutineScreen";
 import { ExerciseSetupScreen } from "./screens/ExerciseSetupScreen";
+import EditMeasurementsScreen from "./screens/EditMeasurementsScreen";
 
 import { ProgressScreen } from "./screens/ProgressScreen";
 import { ProfileScreen } from "./screens/ProfileScreen";
@@ -31,10 +32,12 @@ interface AppRouterProps {
   onNavigateToSignIn: () => void;
 
   onCreateRoutine: () => void;
+  onEditMeasurements: () => void;
   /** Passes (name, id) to jump straight to ExerciseSetup */
   onRoutineCreated: (routineName: string, routineId: number) => void;
 
   onCloseCreateRoutine: () => void;
+  onCloseEditMeasurements: () => void;
   onCompleteRoutineCreation: () => void;
 
   onExerciseSelected: (exercises: Exercise[]) => void;
@@ -68,8 +71,10 @@ export function AppRouter({
   onNavigateToSignIn,
 
   onCreateRoutine,
+  onEditMeasurements,
   onRoutineCreated,
   onCloseCreateRoutine,
+  onCloseEditMeasurements,
   onCompleteRoutineCreation,
 
   onExerciseSelected,
@@ -109,6 +114,7 @@ export function AppRouter({
       {currentView === "workouts" && (
         <WorkoutDashboardScreen
           onCreateRoutine={onCreateRoutine}
+          onEditMeasurements={onEditMeasurements}
           onSelectRoutine={onSelectRoutine}
           // ⬇️ forward overlay visibility changes to App (to hide bottom nav)
           onOverlayChange={onOverlayChange}
@@ -121,6 +127,10 @@ export function AppRouter({
           onBack={onCloseCreateRoutine}
           onRoutineCreated={onRoutineCreated} // (name, id)
         />
+      )}
+
+      {currentView === "edit-measurements" && (
+        <EditMeasurementsScreen onBack={onCloseEditMeasurements} />
       )}
 
       {currentView === "add-exercises-to-routine" && currentRoutineName && (

--- a/components/FabSpeedDial.tsx
+++ b/components/FabSpeedDial.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Plus } from "lucide-react";
+
+export interface FabAction {
+  label: string;
+  onPress: () => void;
+}
+
+interface FabSpeedDialProps {
+  actions: FabAction[];
+  onOpenChange?: (open: boolean) => void;
+}
+
+export default function FabSpeedDial({ actions, onOpenChange }: FabSpeedDialProps) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = () => {
+    setOpen((o) => {
+      const next = !o;
+      onOpenChange?.(next);
+      return next;
+    });
+  };
+
+  const close = () => {
+    setOpen(false);
+    onOpenChange?.(false);
+  };
+
+  const radius = 30;
+  const spacing = 45;
+  const startAngle = 180 - spacing * (actions.length - 1);
+  const maxLabelLength = Math.max(...actions.map((a) => a.label.length));
+  const overlaySize = radius + maxLabelLength * 8 + 100;
+
+  return (
+    <>
+      {open && (
+        <div className="fixed inset-0 z-30" onClick={close}>
+          <div
+            className="absolute right-0 bottom-0 bg-background/80 backdrop-blur-md rounded-tl-full pointer-events-none"
+            style={{ width: overlaySize, height: overlaySize }}
+          />
+        </div>
+      )}
+      <div className="fixed right-4 bottom-24 z-40">
+        {open &&
+          actions.map((action, index) => {
+            const angle = startAngle + index * spacing;
+            const rad = (angle * Math.PI) / 180;
+            const x = Math.cos(rad) * radius;
+            const y = Math.sin(rad) * radius;
+            return (
+              <button
+                key={action.label}
+                onClick={() => {
+                  close();
+                  action.onPress();
+                }}
+                className="absolute text-xl font-medium-lg font-mono uppercase text-primary text-right whitespace-nowrap"
+                style={{ transform: `translate(${x}px, ${-y}px) translateX(-100%)` }}
+                aria-label={action.label}
+              >
+                {action.label}
+              </button>
+            );
+          })}
+        <button
+          onClick={toggle}
+          className="w-16 h-16 rounded-full bg-primary text-primary-foreground shadow-lg flex items-center justify-center"
+          aria-label="Speed dial"
+        >
+          <Plus className={`w-6 h-6 transition-transform ${open ? "rotate-45" : ""}`} />
+        </button>
+      </div>
+    </>
+  );
+}

--- a/components/screens/EditMeasurementsScreen.tsx
+++ b/components/screens/EditMeasurementsScreen.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { AppScreen, ScreenHeader, Section, Stack, Spacer } from "../layouts";
+import { Input } from "../ui/input";
+import { TactileButton } from "../TactileButton";
+import { toast } from "sonner";
+
+interface EditMeasurementsScreenProps {
+  onBack: () => void;
+}
+
+export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScreenProps) {
+  const [weight, setWeight] = useState("");
+  const [height, setHeight] = useState("");
+
+  const handleSave = () => {
+    // Placeholder save handler
+    toast.success("Measurements saved");
+    onBack();
+  };
+
+  return (
+    <AppScreen
+      header={<ScreenHeader title="Edit Measurements" onBack={onBack} showBorder={false} denseSmall contentHeightPx={74} titleClassName="text-[17px] font-bold" />}
+      maxContent="responsive"
+      padContent={false}
+      showHeaderBorder={false}
+      showBottomBarBorder={false}
+      bottomBar={null}
+      bottomBarSticky
+      contentClassName=""
+    >
+      <Stack gap="fluid">
+        <Spacer y="sm" />
+        <Section variant="card" padding="md" className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm text-warm-brown">Weight (kg)</label>
+            <Input value={weight} onChange={(e) => setWeight(e.target.value)} placeholder="e.g. 70" />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm text-warm-brown">Height (cm)</label>
+            <Input value={height} onChange={(e) => setHeight(e.target.value)} placeholder="e.g. 175" />
+          </div>
+        </Section>
+        <Spacer y="sm" />
+        <Section variant="plain" padding="none">
+          <TactileButton
+            onClick={handleSave}
+            className="w-full h-12 md:h-14 bg-primary hover:bg-primary-hover text-primary-foreground font-medium text-sm md:text-base rounded-full border-0"
+          >
+            SAVE
+          </TactileButton>
+        </Section>
+      </Stack>
+    </AppScreen>
+  );
+}

--- a/components/screens/WorkoutDashboardScreen.tsx
+++ b/components/screens/WorkoutDashboardScreen.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { TactileButton } from "../TactileButton";
-import { AlertCircle, Clock3 as Clock, TrendingUp, Plus } from "lucide-react";
+import { AlertCircle, Clock3 as Clock, TrendingUp } from "lucide-react";
 import { useStepTracking } from "../../hooks/useStepTracking";
 import { supabaseAPI, UserRoutine } from "../../utils/supabase/supabase-api";
 import { useAuth } from "../AuthContext";
@@ -14,9 +14,11 @@ import { logger } from "../../utils/logging";
 import { performanceTimer } from "../../utils/performanceTimer";
 import { loadRoutineExercisesWithSets } from "../../utils/routineLoader";
 import ListItem from "../ui/ListItem";
+import FabSpeedDial from "../FabSpeedDial";
 
 interface WorkoutDashboardScreenProps {
   onCreateRoutine: () => void;
+  onEditMeasurements: () => void;
   onSelectRoutine: (routineId: number, routineName: string, access?: RoutineAccess) => void;
   onOverlayChange?: (open: boolean) => void;
   bottomBar?: React.ReactNode;
@@ -38,6 +40,7 @@ const avatarPalette = [
 
 export default function WorkoutDashboardScreen({
   onCreateRoutine,
+  onEditMeasurements,
   onSelectRoutine,
   onOverlayChange,
   bottomBar
@@ -204,6 +207,7 @@ export default function WorkoutDashboardScreen({
     setDeleteLoading(false);
     onOverlayChange?.(false);
   };
+
 
   return (
     <AppScreen
@@ -493,13 +497,19 @@ export default function WorkoutDashboardScreen({
       </Stack>
 
       {canEdit && (
-        <TactileButton
-          onClick={onCreateRoutine}
-          className="fixed z-40 rounded-full shadow-lg right-4 bottom-24 bg-primary hover:bg-primary-hover text-primary-foreground p-4"
-          aria-label="Create routine"
-        >
-          <Plus className="w-6 h-6" />
-        </TactileButton>
+        <FabSpeedDial
+          actions={[
+            {
+              label: "Create Routine",
+              onPress: onCreateRoutine,
+            },
+            {
+              label: "Edit Measurement",
+              onPress: onEditMeasurements,
+            },
+          ]}
+          onOpenChange={onOverlayChange}
+        />
       )}
     </AppScreen>
   );

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -61,6 +61,7 @@ export function useAppNavigation() {
   };
 
   const showCreateRoutine = () => setCurrentView("create-routine");
+  const showEditMeasurements = () => setCurrentView("edit-measurements");
 
   /** After CreateRoutineScreen creates a routine, jump to ExerciseSetup (empty) */
   const handleRoutineCreated = (routineName: string, routineId?: number) => {
@@ -109,6 +110,7 @@ export function useAppNavigation() {
 
 
   const closeCreateRoutine = () => setCurrentView("workouts");
+  const closeEditMeasurements = () => setCurrentView("workouts");
 
   const completeRoutineCreation = () => {
     setCurrentRoutineId(null);
@@ -151,8 +153,10 @@ export function useAppNavigation() {
     handleTabChange,
 
     showCreateRoutine,
+    showEditMeasurements,
     handleRoutineCreated,
     closeCreateRoutine,
+    closeEditMeasurements,
     completeRoutineCreation,
 
     handleExercisesSelected,

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -5,6 +5,7 @@ export type AppView =
   | "create-routine"
   | "add-exercises-to-routine"
   | "exercise-setup"
+  | "edit-measurements"
 
   | "progress"
   | "profile";
@@ -15,6 +16,7 @@ export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "create-routine",
   "add-exercises-to-routine",
   "exercise-setup",
+  "edit-measurements",
 
 ];
 


### PR DESCRIPTION
## Summary
- add `edit-measurements` view and new EditMeasurementsScreen with placeholder fields
- wire navigation and app router to support editing measurements
- replace floating action button with text-only radial speed dial for creating routines or editing measurements
- enlarge and right-align radial speed-dial action labels and blur/dim background when open
- refine speed dial by moving text actions closer and styling labels in uppercase typewriter font
- soften speed dial overlay with app-background tint and reduce radial distance

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb260e7ed08321bd316bea3dcb3f80