### PR TITLE
Display date and value in measurement history

### DIFF
--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -3,12 +3,17 @@ import ExpandingCard from "../ui/ExpandingCard";
 import { Input } from "../ui/input";
 import { Minus, Plus } from "lucide-react";
 
+interface MeasurementHistoryEntry {
+  date: string;
+  value: string;
+}
+
 interface MeasurementCardProps {
   label: string;
   icon: React.ReactNode;
   unit?: string;
   initial?: string;
-  history?: string[]; // most recent first
+  history?: MeasurementHistoryEntry[]; // most recent first
 }
 
 export default function MeasurementCard({
@@ -20,7 +25,6 @@ export default function MeasurementCard({
 }: MeasurementCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [value, setValue] = useState(initial);
-  const [past, setPast] = useState(history);
 
   const step = 0.5;
   const parse = (v: string) => {
@@ -38,15 +42,8 @@ export default function MeasurementCard({
     setValue(e.target.value);
   };
 
-  const handlePastChange = (idx: number, v: string) => {
-    setPast((arr) => {
-      const copy = [...arr];
-      copy[idx] = v;
-      return copy;
-    });
-  };
-
-  const diff = past[0] != null ? parse(value) - parse(past[0]) : null;
+  const diff =
+    history[0] != null ? parse(value) - parse(history[0].value) : null;
   const diffText = diff != null ? `${diff >= 0 ? "+" : ""}${diff.toFixed(1)}${unit}` : undefined;
 
   return (
@@ -96,21 +93,19 @@ export default function MeasurementCard({
         </div>
       }
     >
-      <div className="space-y-3" onClick={(e) => e.stopPropagation()}>
-        {past.slice(0, 4).map((p, i) => (
-          <div key={i} className="flex items-center justify-between gap-2">
-            <span className="text-sm text-warm-brown/60">Entry {i + 1}</span>
-            <div className="flex items-center gap-2">
-              <Input
-                value={p}
-                onChange={(e) => handlePastChange(i, e.target.value)}
-                className="h-7 text-center px-1 w-[6.5rem] sm:w-[7.5rem]"
-              />
-              <span className="text-sm text-warm-brown">{unit}</span>
+      {history.length > 0 && (
+        <div className="space-y-3" onClick={(e) => e.stopPropagation()}>
+          {history.slice(0, 4).map((p, i) => (
+            <div key={i} className="flex items-center justify-between gap-2">
+              <span className="text-sm text-warm-brown/60">{p.date}</span>
+              <span className="text-sm text-warm-brown">
+                {p.value}
+                {unit}
+              </span>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </ExpandingCard>
   );
 }

--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -25,6 +25,7 @@ export default function MeasurementCard({
 }: MeasurementCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [value, setValue] = useState(initial);
+  const [past, setPast] = useState(history);
 
   const step = 0.5;
   const parse = (v: string) => {
@@ -42,8 +43,15 @@ export default function MeasurementCard({
     setValue(e.target.value);
   };
 
-  const diff =
-    history[0] != null ? parse(value) - parse(history[0].value) : null;
+  const handlePastChange = (idx: number, v: string) => {
+    setPast((arr) => {
+      const copy = [...arr];
+      copy[idx] = { ...copy[idx], value: v };
+      return copy;
+    });
+  };
+
+  const diff = past[0] != null ? parse(value) - parse(past[0].value) : null;
   const diffText = diff != null ? `${diff >= 0 ? "+" : ""}${diff.toFixed(1)}${unit}` : undefined;
 
   return (
@@ -93,15 +101,19 @@ export default function MeasurementCard({
         </div>
       }
     >
-      {history.length > 0 && (
+      {past.length > 0 && (
         <div className="space-y-3" onClick={(e) => e.stopPropagation()}>
-          {history.slice(0, 4).map((p, i) => (
+          {past.slice(0, 4).map((p, i) => (
             <div key={i} className="flex items-center justify-between gap-2">
               <span className="text-sm text-warm-brown/60">{p.date}</span>
-              <span className="text-sm text-warm-brown">
-                {p.value}
-                {unit}
-              </span>
+              <div className="flex items-center gap-2">
+                <Input
+                  value={p.value}
+                  onChange={(e) => handlePastChange(i, e.target.value)}
+                  className="h-7 text-center px-1 w-[6.5rem] sm:w-[7.5rem]"
+                />
+                <span className="text-sm text-warm-brown">{unit}</span>
+              </div>
             </div>
           ))}
         </div>

--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -84,6 +84,11 @@ export default function MeasurementCard({
             </button>
 
             <Input
+              type="number"
+              inputMode="decimal"
+              pattern="[0-9]*[.,]?[0-9]*"
+              step="0.5"
+              min="0"
               value={value}
               onChange={handleChange}
               placeholder={unit}
@@ -108,6 +113,11 @@ export default function MeasurementCard({
               <span className="text-sm text-warm-brown/60">{p.date}</span>
               <div className="flex items-center gap-2">
                 <Input
+                  type="number"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
+                  step="0.5"
+                  min="0"
                   value={p.value}
                   onChange={(e) => handlePastChange(i, e.target.value)}
                   className="h-7 text-center px-1 w-[6.5rem] sm:w-[7.5rem]"

--- a/components/screens/EditMeasurementsScreen.tsx
+++ b/components/screens/EditMeasurementsScreen.tsx
@@ -1,5 +1,6 @@
 import { AppScreen, ScreenHeader, Section, Stack, Spacer } from "../layouts";
-import { TactileButton } from "../TactileButton";
+import { BottomNavigation } from "../BottomNavigation";
+import { BottomNavigationButton } from "../BottomNavigationButton";
 import { toast } from "sonner";
 import { TrendingUp } from "lucide-react";
 import MeasurementCard from "../measurements/MeasurementCard";
@@ -103,7 +104,16 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
       padContent={false}
       showHeaderBorder={false}
       showBottomBarBorder={false}
-      bottomBar={null}
+      bottomBar={
+        <BottomNavigation>
+          <BottomNavigationButton
+            onClick={handleSave}
+            className="px-6 md:px-8 font-medium border-0 transition-all bg-primary hover:bg-primary-hover text-primary-foreground btn-tactile"
+          >
+            SAVE CHANGES
+          </BottomNavigationButton>
+        </BottomNavigation>
+      }
       bottomBarSticky
       contentClassName=""
     >
@@ -124,14 +134,6 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
           </div>
         ))}
         <Spacer y="sm" />
-        <Section variant="plain" padding="none">
-          <TactileButton
-            onClick={handleSave}
-            className="w-full h-12 md:h-14 bg-primary hover:bg-primary-hover text-primary-foreground font-medium text-sm md:text-base rounded-full border-0"
-          >
-            Save Measurements
-          </TactileButton>
-        </Section>
       </Stack>
     </AppScreen>
   );


### PR DESCRIPTION
## Summary
- Show measurement history entries with their logged date and value when a measurement card is expanded
- Track history entries as objects with date and value for clearer diff calculations

## Testing
- `npm test` *(fails: validateSignInResult(signInResult) toBe true)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4636a15483219acc9008f9a38f2b