### PR TITLE
Hide bottom bar when keyboard is visible

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { useMobileSetup } from "./hooks/useMobileSetup";
 import { Toaster } from "./components/ui/sonner";
 import { useState } from "react";
 import ThemeToggle from "./components/ThemeToggle";
+import { useKeyboardVisible } from "./hooks/useKeyboardVisible";
 
 import { BottomNavigation, TabType } from "./components/BottomNavigation";
 import { VIEWS_WITHOUT_BOTTOM_NAV } from "./utils/navigation";
@@ -52,8 +53,9 @@ function AppContent() {
 
   const showBottomNav = !VIEWS_WITHOUT_BOTTOM_NAV.includes(currentView);
   const [overlayOpen, setOverlayOpen] = useState(false);
+  const keyboardVisible = useKeyboardVisible();
 
-  const showNav = isAuthenticated && showBottomNav && !overlayOpen;
+  const showNav = isAuthenticated && showBottomNav && !overlayOpen && !keyboardVisible;
   const bottomBarEl = showNav ? (
     <BottomNavigation
       activeTab={activeTab as TabType}

--- a/hooks/useKeyboardVisible.ts
+++ b/hooks/useKeyboardVisible.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Hook that returns true when the on-screen keyboard is visible.
+ * Works for both Capacitor (native) and web environments.
+ */
+export function useKeyboardVisible(): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let raf = 0;
+    let capCleanup: (() => void) | null = null;
+
+    const updateFromViewport = () => {
+      const vv = window.visualViewport;
+      if (!vv) {
+        setVisible(false);
+        return;
+      }
+      const inset = Math.max(0, window.innerHeight - vv.height - (vv.offsetTop || 0));
+      setVisible(inset > 0);
+    };
+
+    const onChange = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(updateFromViewport);
+    };
+
+    const attach = async () => {
+      // Capacitor keyboard events (native mobile)
+      try {
+        const { Capacitor } = await import("@capacitor/core");
+        const { Keyboard } = await import("@capacitor/keyboard");
+        if (Capacitor.isNativePlatform()) {
+          const showListener = await Keyboard.addListener("keyboardWillShow", () => setVisible(true));
+          const hideListener = await Keyboard.addListener("keyboardWillHide", () => setVisible(false));
+          capCleanup = () => {
+            showListener.remove();
+            hideListener.remove();
+          };
+          return;
+        }
+      } catch {
+        /* capacitor not available - fall back to web */
+      }
+
+      // Web fallback using VisualViewport
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener("resize", onChange);
+        window.visualViewport.addEventListener("scroll", onChange);
+      } else {
+        window.addEventListener("resize", onChange);
+      }
+
+      capCleanup = () => {
+        if (window.visualViewport) {
+          window.visualViewport.removeEventListener("resize", onChange);
+          window.visualViewport.removeEventListener("scroll", onChange);
+        } else {
+          window.removeEventListener("resize", onChange);
+        }
+      };
+    };
+
+    void attach();
+    updateFromViewport();
+
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      capCleanup?.();
+    };
+  }, []);
+
+  return visible;
+}


### PR DESCRIPTION
## Summary
- detect on-screen keyboard via new `useKeyboardVisible` hook
- hide bottom navigation while keyboard is open

## Testing
- `npm test` *(fails: Real Authentication Integration Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4e048fe0832196d1d34e05b7b003