### PR TITLE
Refactor FabSpeedDial to vertical layout

### DIFF
--- a/components/FabSpeedDial.tsx
+++ b/components/FabSpeedDial.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import { Plus } from "lucide-react";
 import { logger } from "../utils/logging";
 
 export interface FabAction {
   label: string;
   onPress: () => void;
+  icon?: ReactNode;
 }
 
 interface FabSpeedDialProps {
@@ -28,18 +29,14 @@ export default function FabSpeedDial({ actions, onOpenChange }: FabSpeedDialProp
     onOpenChange?.(false);
   };
 
-  // --- geometry ---
+  // --- geometry for overlay ---
   const count = actions.length;
-  const radius = 10;
-  const spacing = 50;
-  const totalSpread = spacing * Math.max(count - 1, 0);
-  const startAngle = 180 - totalSpread;      // fan from bottom-right upward
-  const factor = 4.7;
-
+  const spacing = 56;
   const maxLabelLength = count ? Math.max(...actions.map((a) => a.label.length)) : 0;
-  const overlaySize = radius * factor * 4 + maxLabelLength * 8 + 100;
+  const overlayWidth = maxLabelLength * 8 + 160;
+  const overlayHeight = count * spacing + 160;
 
-  logger.info("overlaySize", overlaySize);
+  logger.info("overlayWidth", overlayWidth, "overlayHeight", overlayHeight);
 
   return (
     <>
@@ -49,8 +46,8 @@ export default function FabSpeedDial({ actions, onOpenChange }: FabSpeedDialProp
           <div
             className="absolute right-0 bottom-0 pointer-events-none"
             style={{
-              width: overlaySize,
-              height: overlaySize,
+              width: overlayWidth,
+              height: overlayHeight,
               background: "rgba(61,41,20,0.16)",
               WebkitMaskImage:
                 "radial-gradient(120% 120% at 100% 100%, #000 0%, #000 55%, transparent 78%)",
@@ -68,30 +65,28 @@ export default function FabSpeedDial({ actions, onOpenChange }: FabSpeedDialProp
 
 
       {/* Actions + FAB */}
-      <div className="fixed right-4 bottom-24 z-40">
+      <div className="fixed right-4 bottom-24 z-40 flex flex-col items-end gap-4">
         {open &&
-          actions.map((action, index) => {
-            const angle = startAngle + index * spacing;
-            const rad = (angle * Math.PI) / 180;
-            const x = Math.cos(rad) * radius * factor;
-            const y = Math.sin(rad) * radius * factor;
-
-            return (
-              <button
-                key={action.label}
-                onClick={() => { close(); action.onPress(); }}
-                className="
-    absolute uppercase whitespace-nowrap
-    text-primary text-xl font-bold tracking-wide
-  "
-                style={{ textShadow: 'none', transform: `translate(${x}px, ${-y}px) translateX(-100%)` }}
-
-              >
+          actions.map((action) => (
+            <button
+              key={action.label}
+              onClick={() => {
+                close();
+                action.onPress();
+              }}
+              className="flex items-center gap-3"
+              style={{ textShadow: "none" }}
+            >
+              {action.icon && (
+                <span className="w-12 h-12 rounded-full bg-primary text-primary-foreground shadow flex items-center justify-center">
+                  {action.icon}
+                </span>
+              )}
+              <span className="uppercase whitespace-nowrap text-primary text-xl font-bold tracking-wide">
                 {action.label}
-              </button>
-
-            );
-          })}
+              </span>
+            </button>
+          ))}
 
         <button
           onClick={toggle}

--- a/components/screens/WorkoutDashboardScreen.tsx
+++ b/components/screens/WorkoutDashboardScreen.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { TactileButton } from "../TactileButton";
-import { AlertCircle, Clock3 as Clock, TrendingUp } from "lucide-react";
+import { AlertCircle, Clock3 as Clock, TrendingUp, Dumbbell, Ruler } from "lucide-react";
 import { useStepTracking } from "../../hooks/useStepTracking";
 import { supabaseAPI, UserRoutine, Profile } from "../../utils/supabase/supabase-api";
 import { useAuth } from "../AuthContext";
@@ -528,10 +528,12 @@ export default function WorkoutDashboardScreen({
             {
               label: "Create Routine",
               onPress: onCreateRoutine,
+              icon: <Dumbbell className="w-6 h-6" />,
             },
             {
               label: "Edit Measurement",
               onPress: onEditMeasurements,
+              icon: <Ruler className="w-6 h-6" />,
             },
           ]}
           onOpenChange={onOverlayChange}


### PR DESCRIPTION
## Summary
- Refactor FabSpeedDial to stack actions vertically and support optional icons
- Add icons to WorkoutDashboardScreen speed dial actions

## Testing
- `npm test` *(fails: Real Authentication Integration Tests - expected Sign Up/Sign In results)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd3b3444883219fea126a861b4164