### PR TITLE
feat: fetch and save body measurements

### DIFF
--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -12,7 +12,8 @@ interface MeasurementCardProps {
   label: string;
   icon: React.ReactNode;
   unit?: string;
-  initial?: string;
+  value: string;
+  onValueChange: (v: string) => void;
   history?: MeasurementHistoryEntry[]; // most recent first
 }
 
@@ -20,12 +21,11 @@ export default function MeasurementCard({
   label,
   icon,
   unit = "cm",
-  initial = "",
+  value,
+  onValueChange,
   history = [],
 }: MeasurementCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [value, setValue] = useState(initial);
-  const [past, setPast] = useState(history);
 
   const step = 0.5;
   const parse = (v: string) => {
@@ -33,25 +33,17 @@ export default function MeasurementCard({
     return isNaN(n) ? 0 : n;
   };
   const update = (delta: number) => {
-    setValue((prev) => (parse(prev) + delta).toFixed(1));
+    onValueChange((parse(value) + delta).toFixed(1));
   };
 
   const handleDec = (e: React.MouseEvent) => { e.stopPropagation(); update(-step); };
   const handleInc = (e: React.MouseEvent) => { e.stopPropagation(); update(step); };
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    setValue(e.target.value);
+    onValueChange(e.target.value);
   };
 
-  const handlePastChange = (idx: number, v: string) => {
-    setPast((arr) => {
-      const copy = [...arr];
-      copy[idx] = { ...copy[idx], value: v };
-      return copy;
-    });
-  };
-
-  const diff = past[0] != null ? parse(value) - parse(past[0].value) : null;
+  const diff = history[0] != null ? parse(value) - parse(history[0].value) : null;
   const diffText = diff != null ? `${diff >= 0 ? "+" : ""}${diff.toFixed(1)}${unit}` : undefined;
 
   return (
@@ -106,22 +98,13 @@ export default function MeasurementCard({
         </div>
       }
     >
-      {past.length > 0 && (
+      {history.length > 0 && (
         <div className="space-y-3" onClick={(e) => e.stopPropagation()}>
-          {past.slice(0, 4).map((p, i) => (
+          {history.slice(0, 4).map((p, i) => (
             <div key={i} className="flex items-center justify-between gap-2">
               <span className="text-sm text-warm-brown/60">{p.date}</span>
               <div className="flex items-center gap-2">
-                <Input
-                  type="number"
-                  inputMode="decimal"
-                  pattern="[0-9]*[.,]?[0-9]*"
-                  step="0.5"
-                  min="0"
-                  value={p.value}
-                  onChange={(e) => handlePastChange(i, e.target.value)}
-                  className="h-7 text-center px-1 w-[6.5rem] sm:w-[7.5rem]"
-                />
+                <span className="text-sm text-warm-brown">{p.value}</span>
                 <span className="text-sm text-warm-brown">{unit}</span>
               </div>
             </div>

--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -3,7 +3,7 @@ import ExpandingCard from "../ui/ExpandingCard";
 import { Input } from "../ui/input";
 import { Minus, Plus } from "lucide-react";
 
-interface MeasurementHistoryEntry {
+interface MeasurementEntry {
   date: string;
   value: string;
 }
@@ -12,18 +12,16 @@ interface MeasurementCardProps {
   label: string;
   icon: React.ReactNode;
   unit?: string;
-  value: string;
-  onValueChange: (v: string) => void;
-  history?: MeasurementHistoryEntry[]; // most recent first
+  entries: MeasurementEntry[]; // index 0 is today
+  onEntryChange: (index: number, value: string) => void;
 }
 
 export default function MeasurementCard({
   label,
   icon,
   unit = "cm",
-  value,
-  onValueChange,
-  history = [],
+  entries,
+  onEntryChange,
 }: MeasurementCardProps) {
   const [expanded, setExpanded] = useState(false);
 
@@ -33,18 +31,29 @@ export default function MeasurementCard({
     return isNaN(n) ? 0 : n;
   };
   const update = (delta: number) => {
-    onValueChange((parse(value) + delta).toFixed(1));
+    const current = entries[0]?.value ?? "0";
+    onEntryChange(0, (parse(current) + delta).toFixed(1));
   };
 
-  const handleDec = (e: React.MouseEvent) => { e.stopPropagation(); update(-step); };
-  const handleInc = (e: React.MouseEvent) => { e.stopPropagation(); update(step); };
+  const handleDec = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    update(-step);
+  };
+  const handleInc = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    update(step);
+  };
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
-    onValueChange(e.target.value);
+    onEntryChange(0, e.target.value);
   };
 
-  const diff = history[0] != null ? parse(value) - parse(history[0].value) : null;
-  const diffText = diff != null ? `${diff >= 0 ? "+" : ""}${diff.toFixed(1)}${unit}` : undefined;
+  const diff =
+    entries[1] != null
+      ? parse(entries[0]?.value ?? "0") - parse(entries[1].value)
+      : null;
+  const diffText =
+    diff != null ? `${diff >= 0 ? "+" : ""}${diff.toFixed(1)}${unit}` : undefined;
 
   return (
     <ExpandingCard
@@ -81,7 +90,7 @@ export default function MeasurementCard({
               pattern="[0-9]*[.,]?[0-9]*"
               step="0.5"
               min="0"
-              value={value}
+              value={entries[0]?.value ?? ""}
               onChange={handleChange}
               placeholder={unit}
               className="h-7 text-center px-1 w-full"
@@ -98,13 +107,22 @@ export default function MeasurementCard({
         </div>
       }
     >
-      {history.length > 0 && (
+      {entries.length > 0 && (
         <div className="space-y-3" onClick={(e) => e.stopPropagation()}>
-          {history.slice(0, 4).map((p, i) => (
+          {entries.slice(0, 4).map((p, i) => (
             <div key={i} className="flex items-center justify-between gap-2">
               <span className="text-sm text-warm-brown/60">{p.date}</span>
               <div className="flex items-center gap-2">
-                <span className="text-sm text-warm-brown">{p.value}</span>
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  pattern="[0-9]*[.,]?[0-9]*"
+                  step="0.5"
+                  min="0"
+                  value={p.value}
+                  onChange={(e) => onEntryChange(i, e.target.value)}
+                  className="h-7 text-center px-1 w-[6.5rem] sm:w-[7.5rem]"
+                />
                 <span className="text-sm text-warm-brown">{unit}</span>
               </div>
             </div>

--- a/components/measurements/measurementJournal.ts
+++ b/components/measurements/measurementJournal.ts
@@ -1,0 +1,36 @@
+export type MeasurementJournalAction = {
+  t: "UPDATE";
+  date: string;
+  key: string;
+  value: string;
+};
+
+export type MeasurementJournal = MeasurementJournalAction[];
+
+export function makeMeasurementJournal(): MeasurementJournal {
+  return [];
+}
+
+export function recordMeasurementUpdate(
+  journal: MeasurementJournal,
+  date: string,
+  key: string,
+  value: string
+) {
+  journal.push({ t: "UPDATE", date, key, value });
+}
+
+export function measurementJournalIsNoop(journal: MeasurementJournal): boolean {
+  return journal.length === 0;
+}
+
+export function collapseMeasurementJournal(
+  journal: MeasurementJournal
+): Record<string, Record<string, string>> {
+  const byDate: Record<string, Record<string, string>> = {};
+  for (const action of journal) {
+    if (!byDate[action.date]) byDate[action.date] = {};
+    byDate[action.date][action.key] = action.value;
+  }
+  return byDate;
+}

--- a/components/screens/EditMeasurementsScreen.tsx
+++ b/components/screens/EditMeasurementsScreen.tsx
@@ -52,7 +52,12 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
       });
       data = [newRow, ...rows];
     }
-    data = data.slice(0, 4);
+    data = data
+      .sort(
+        (a, b) =>
+          new Date(b.measured_on).getTime() - new Date(a.measured_on).getTime()
+      )
+      .slice(0, 4);
     const mapped = data.map((r) => {
       const obj: any = { measured_on: r.measured_on };
       measurementParts.forEach((part) => {

--- a/components/screens/EditMeasurementsScreen.tsx
+++ b/components/screens/EditMeasurementsScreen.tsx
@@ -147,8 +147,14 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
                 setEntries((prev) => {
                   const next = [...prev];
                   const date = next[index].measured_on;
-                  next[index] = { ...next[index], [m.key]: value };
-                  recordMeasurementUpdate(journalRef.current, date, m.key, value);
+                  const normalized = value === "" ? "" : String(parseFloat(value));
+                  next[index] = { ...next[index], [m.key]: normalized };
+                  recordMeasurementUpdate(
+                    journalRef.current,
+                    date,
+                    m.key,
+                    normalized
+                  );
                   return next;
                 })
               }

--- a/utils/supabase/cache-keys.ts
+++ b/utils/supabase/cache-keys.ts
@@ -16,3 +16,5 @@ export const fullCacheKeyProfile = (userId: string) =>
   `supabase:${userId}:profile`;
 export const fullCacheKeySteps = (userId: string) =>
   `supabase:${userId}:steps`;
+export const fullCacheKeyBodyMeasurements = (userId: string) =>
+  `supabase:${userId}:bodyMeasurements`;

--- a/utils/supabase/supabase-base.ts
+++ b/utils/supabase/supabase-base.ts
@@ -9,6 +9,7 @@ import {
   fullCacheKeyRoutineSets,
   fullCacheKeyUserRoutines,
   fullCacheKeySteps,
+  fullCacheKeyBodyMeasurements,
 } from "./cache-keys";
 import { logger } from "../logging";
 
@@ -26,6 +27,7 @@ export const CACHE_TTL = {
   routineSets: 60 * 60 * 1000,
   profile: 60 * 60 * 1000,
   steps: 60 * 60 * 1000,
+  bodyMeasurements: 60 * 60 * 1000,
 };
 
 export const PREFER_CACHE_ON_READ = true;
@@ -261,6 +263,22 @@ export class SupabaseBase {
     logger.db("🔍 [CACHE REFRESH COMPLETE] Steps refreshed, count:", rows.length);
   }
 
+  protected async refreshBodyMeasurements(userId: string) {
+    const stackTrace = new Error().stack;
+    logger.db("🔍 [CACHE REFRESH TRIGGER] refreshBodyMeasurements called by:", stackTrace);
+    logger.db("🔍 [CACHE REFRESH TRIGGER] User ID:", userId);
+
+    const url = `${SUPABASE_URL}/rest/v1/user_body_measurements?user_id=eq.${userId}&select=*`;
+    const key = fullCacheKeyBodyMeasurements(userId);
+    logger.db("🔍 [CACHE REFRESH TRIGGER] Cache key:", key);
+    logger.db("🔍 [CACHE REFRESH TRIGGER] URL:", url);
+
+    const rows = await this.fetchJson<any[]>(url, true);
+    localCache.set(key, rows);
+    logger.db("🔍 [CACHE REFRESH] body measurements", key);
+    logger.db("🔍 [CACHE REFRESH COMPLETE] Body measurements refreshed, count:", rows.length);
+  }
+
   // ---------- Common keys (exported so reads/writes can use) ----------
   protected keyExercises = () => fullCacheKeyExercises();
   protected keyExercise = (id: number) => fullCacheKeyExercise(id);
@@ -270,4 +288,5 @@ export class SupabaseBase {
   protected keyRoutineSets = (userId: string, rtexId: number) => fullCacheKeyRoutineSets(userId, rtexId);
   protected keyProfile = (userId: string) => fullCacheKeyProfile(userId);
   protected keySteps = (userId: string) => fullCacheKeySteps(userId);
+  protected keyBodyMeasurements = (userId: string) => fullCacheKeyBodyMeasurements(userId);
 }

--- a/utils/supabase/supabase-base.ts
+++ b/utils/supabase/supabase-base.ts
@@ -268,7 +268,7 @@ export class SupabaseBase {
     logger.db("🔍 [CACHE REFRESH TRIGGER] refreshBodyMeasurements called by:", stackTrace);
     logger.db("🔍 [CACHE REFRESH TRIGGER] User ID:", userId);
 
-    const url = `${SUPABASE_URL}/rest/v1/user_body_measurements?user_id=eq.${userId}&select=*`;
+    const url = `${SUPABASE_URL}/rest/v1/user_body_measurements?user_id=eq.${userId}&select=*&order=measured_on.desc`;
     const key = fullCacheKeyBodyMeasurements(userId);
     logger.db("🔍 [CACHE REFRESH TRIGGER] Cache key:", key);
     logger.db("🔍 [CACHE REFRESH TRIGGER] URL:", url);

--- a/utils/supabase/supabase-db-read.ts
+++ b/utils/supabase/supabase-db-read.ts
@@ -5,6 +5,7 @@ import type {
   UserRoutineExercise,
   UserRoutineExerciseSet,
   Profile,
+  BodyMeasurement,
 } from "./supabase-types";
 import { localCache } from "../cache/localCache";
 
@@ -116,6 +117,14 @@ export class SupabaseDBRead extends SupabaseBase {
     const key = this.keyProfile(userId);
     const { data: rows } = await this.getOrFetchAndCache<Profile[]>(url, key, CACHE_TTL.profile, true);
     return rows[0] ?? null;
+  }
+
+  async getBodyMeasurements(limit = 4): Promise<BodyMeasurement[]> {
+    const userId = await this.getUserId();
+    const url = `${SUPABASE_URL}/rest/v1/user_body_measurements?user_id=eq.${userId}&select=*&order=measured_on.desc&limit=${limit}`;
+    const key = this.keyBodyMeasurements(userId);
+    const { data: rows } = await this.getOrFetchAndCache<BodyMeasurement[]>(url, key, CACHE_TTL.bodyMeasurements, true);
+    return rows;
   }
 
   // Steps goal (creates a default on first read if none exists)

--- a/utils/supabase/supabase-db-write.ts
+++ b/utils/supabase/supabase-db-write.ts
@@ -585,6 +585,21 @@ export class SupabaseDBWrite extends SupabaseBase {
         );
     }
 
+    async deleteBodyMeasurement(measured_on: string): Promise<void> {
+        return performanceTimer.timeAsync(
+            `[SUPABASE] deleteBodyMeasurement(${measured_on})`,
+            async () => {
+                const userId = await this.getUserId();
+                await this.fetchJson(
+                    `${SUPABASE_URL}/rest/v1/user_body_measurements?user_id=eq.${userId}&measured_on=eq.${measured_on}`,
+                    true,
+                    "DELETE"
+                );
+                await this.refreshBodyMeasurements(userId);
+            }
+        );
+    }
+
     async recomputeAndSaveRoutineMuscleSummary(routineTemplateId: number) {
         return performanceTimer.timeAsync(
             `[SUPABASE] recomputeAndSaveRoutineMuscleSummary(${routineTemplateId})`,

--- a/utils/supabase/supabase-db-write.ts
+++ b/utils/supabase/supabase-db-write.ts
@@ -1,5 +1,5 @@
 import { SupabaseBase, SUPABASE_URL, CACHE_TTL } from "./supabase-base";
-import type { UserRoutine, UserRoutineExercise, UserRoutineExerciseSet, Profile, Workout, WorkoutExercise, Set } from "./supabase-types";
+import type { UserRoutine, UserRoutineExercise, UserRoutineExerciseSet, Profile, Workout, WorkoutExercise, Set, BodyMeasurement } from "./supabase-types";
 import { logger } from "../logging";
 import { performanceTimer } from "../performanceTimer";
 
@@ -562,6 +562,25 @@ export class SupabaseDBWrite extends SupabaseBase {
                 );
                 await this.refreshSteps(userId);
                 return rows[0]?.goal ?? goal;
+            }
+        );
+    }
+
+    async upsertBodyMeasurement(data: Partial<BodyMeasurement> & { measured_on: string }): Promise<BodyMeasurement | null> {
+        return performanceTimer.timeAsync(
+            `[SUPABASE] upsertBodyMeasurement(${data.measured_on})`,
+            async () => {
+                const userId = await this.getUserId();
+                const payload = [{ ...data, user_id: userId }];
+                const rows = await this.fetchJson<BodyMeasurement[]>(
+                    `${SUPABASE_URL}/rest/v1/user_body_measurements?on_conflict=user_id,measured_on`,
+                    true,
+                    "POST",
+                    payload,
+                    "return=representation"
+                );
+                await this.refreshBodyMeasurements(userId);
+                return rows[0] ?? null;
             }
         );
     }

--- a/utils/supabase/supabase-types.ts
+++ b/utils/supabase/supabase-types.ts
@@ -97,7 +97,24 @@ export interface Exercise {
     planned_reps?: number | null;
     planned_weight_kg?: number | null;
     notes?: string;
-  } 
+  }
+
+  export interface BodyMeasurement {
+    id: number;
+    user_id: string;
+    measured_on: string;
+    chest_cm?: number | null;
+    right_arm_cm?: number | null;
+    left_arm_cm?: number | null;
+    waist_cm?: number | null;
+    hip_cm?: number | null;
+    glutes_cm?: number | null;
+    left_quad_cm?: number | null;
+    right_quad_cm?: number | null;
+    left_calf_cm?: number | null;
+    right_calf_cm?: number | null;
+    notes?: string | null;
+  }
   // src/utils/supabase/supabase-types.ts
 export interface Exercise { /* ... */ }
 export interface Workout { /* ... */ }


### PR DESCRIPTION
## Summary
- hook up Edit Measurements screen to Supabase
- add Supabase methods for body measurements with caching
- convert MeasurementCard to controlled component with history display
- ensure only one body measurement per user per day with unique constraint (database migration file removed after manual application)

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68bda4d5a6988321b1c816b5e9811ea9