### PR TITLE
feat: add generic slide transition wrapper

### DIFF
--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -142,15 +142,21 @@ export function AppRouter({
         <EditMeasurementsScreen onBack={onCloseEditMeasurements} />
       </SlideTransition>
 
-      {currentView === "add-exercises-to-routine" && currentRoutineName && (
+      <SlideTransition
+        show={currentView === "add-exercises-to-routine" && !!currentRoutineName}
+        enterFrom="down"
+        exitTo="left"
+      >
         <AddExercisesToRoutineScreen
           routineId={currentRoutineId || undefined}
           routineName={currentRoutineName}
-          onBack={currentRoutineId ? onCloseExerciseSetupToRoutines : onCloseCreateRoutine}
+          onBack={
+            currentRoutineId ? onCloseExerciseSetupToRoutines : onCloseCreateRoutine
+          }
           onExerciseSelected={(exercises: Exercise[]) => onExerciseSelected(exercises)}
           isFromExerciseSetup={!!currentRoutineId}
         />
-      )}
+      </SlideTransition>
 
       <SlideTransition
         show={

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -1,4 +1,4 @@
-import  WorkoutDashboardScreen  from "./screens/WorkoutDashboardScreen";
+import WorkoutDashboardScreen from "./screens/WorkoutDashboardScreen";
 import CreateRoutineScreen from "./screens/CreateRoutineScreen";
 import { AddExercisesToRoutineScreen } from "./screens/AddExercisesToRoutineScreen";
 import { ExerciseSetupScreen } from "./screens/ExerciseSetupScreen";
@@ -13,6 +13,7 @@ import { AppView } from "../utils/navigation";
 import { Exercise } from "../utils/supabase/supabase-api";
 import { RoutineAccess } from "../hooks/useAppNavigation";
 import { logger } from "../utils/logging";
+import { SlideTransition } from "./SlideTransition";
 
 interface AppRouterProps {
   currentView: AppView;
@@ -122,16 +123,24 @@ export function AppRouter({
         />
       )}
 
-      {currentView === "create-routine" && (
+      <SlideTransition
+        show={currentView === "create-routine"}
+        enterFrom="down"
+        exitTo="left"
+      >
         <CreateRoutineScreen
           onBack={onCloseCreateRoutine}
           onRoutineCreated={onRoutineCreated} // (name, id)
         />
-      )}
+      </SlideTransition>
 
-      {currentView === "edit-measurements" && (
+      <SlideTransition
+        show={currentView === "edit-measurements"}
+        enterFrom="down"
+        exitTo="left"
+      >
         <EditMeasurementsScreen onBack={onCloseEditMeasurements} />
-      )}
+      </SlideTransition>
 
       {currentView === "add-exercises-to-routine" && currentRoutineName && (
         <AddExercisesToRoutineScreen
@@ -143,24 +152,30 @@ export function AppRouter({
         />
       )}
 
-      {currentView === "exercise-setup" &&
-        currentRoutineId &&
-        currentRoutineName && (
-          <ExerciseSetupScreen
-            routineId={currentRoutineId}
-            routineName={currentRoutineName}
-            selectedExercisesForSetup={selectedExercisesForSetup}
-            setSelectedExercisesForSetup={setSelectedExercisesForSetup}
-            onBack={onCloseExerciseSetupToRoutines}
-            onSave={onExerciseSetupComplete}
-            onAddMoreExercises={onCloseExerciseSetup}
-            isEditingExistingRoutine={true}
-            onShowExerciseSelector={onCloseExerciseSetup}
-            access={routineAccess}
-            initialMode={exerciseSetupMode}
-            onModeChange={setExerciseSetupMode}
-          />
-        )}
+      <SlideTransition
+        show={
+          currentView === "exercise-setup" &&
+          currentRoutineId !== null &&
+          !!currentRoutineName
+        }
+        enterFrom="right"
+        exitTo="left"
+      >
+        <ExerciseSetupScreen
+          routineId={currentRoutineId!}
+          routineName={currentRoutineName}
+          selectedExercisesForSetup={selectedExercisesForSetup}
+          setSelectedExercisesForSetup={setSelectedExercisesForSetup}
+          onBack={onCloseExerciseSetupToRoutines}
+          onSave={onExerciseSetupComplete}
+          onAddMoreExercises={onCloseExerciseSetup}
+          isEditingExistingRoutine={true}
+          onShowExerciseSelector={onCloseExerciseSetup}
+          access={routineAccess}
+          initialMode={exerciseSetupMode}
+          onModeChange={setExerciseSetupMode}
+        />
+      </SlideTransition>
 
       {currentView === "progress" && <ProgressScreen bottomBar={bottomBar} />}
       {currentView === "profile" && <ProfileScreen bottomBar={bottomBar} />}

--- a/components/SlideTransition.tsx
+++ b/components/SlideTransition.tsx
@@ -1,0 +1,56 @@
+// components/SlideTransition.tsx
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+type Direction = "left" | "right" | "up" | "down";
+
+function getAxisOffset(dir: Direction) {
+  switch (dir) {
+    case "left":
+      return { x: "-100%" };
+    case "right":
+      return { x: "100%" };
+    case "up":
+      return { y: "-100%" };
+    case "down":
+      return { y: "100%" };
+    default:
+      return { x: 0 };
+  }
+}
+
+type SlideTransitionProps = {
+  show: boolean;
+  /** Direction the element enters from */
+  enterFrom?: Direction;
+  /** Direction the element exits to */
+  exitTo?: Direction;
+  /** Animation duration in seconds */
+  duration?: number;
+  children: React.ReactNode;
+};
+
+export function SlideTransition({
+  show,
+  enterFrom = "right",
+  exitTo = enterFrom,
+  duration = 0.3,
+  children,
+}: SlideTransitionProps) {
+  return (
+    <AnimatePresence mode="wait">
+      {show && (
+        <motion.div
+          key="slide"
+          initial={getAxisOffset(enterFrom)}
+          animate={{ x: 0, y: 0 }}
+          exit={getAxisOffset(exitTo)}
+          transition={{ type: "tween", ease: "easeInOut", duration }}
+          style={{ position: "absolute", inset: 0 }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `SlideTransition` component to animate elements into view from any edge
- apply slide-in/out transitions to CreateRoutine, EditMeasurements, and ExerciseSetup screens
- remove unnecessary `relative` positioning from AppRouter container

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68be281cdc0c8321be89c210dac32029