### PR TITLE
feat: add reusable number input component

### DIFF
--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import ExpandingCard from "../ui/ExpandingCard";
-import { Input } from "../ui/input";
+import { NumberInput } from "../ui/number-input";
 import { Minus, Plus } from "lucide-react";
 
 interface MeasurementEntry {
@@ -84,12 +84,10 @@ export default function MeasurementCard({
               <Minus size={14} />
             </button>
 
-            <Input
-              type="number"
-              inputMode="decimal"
-              pattern="[0-9]*[.,]?[0-9]*"
-              step="0.5"
-              min="0"
+            <NumberInput
+              step={step}
+              min={0}
+              mode="decimal"
               value={entries[0]?.value ?? ""}
               onChange={handleChange}
               placeholder={unit}
@@ -113,12 +111,10 @@ export default function MeasurementCard({
             <div key={i} className="flex items-center justify-between gap-2">
               <span className="text-sm text-warm-brown/60">{p.date}</span>
               <div className="flex items-center gap-2">
-                <Input
-                  type="number"
-                  inputMode="decimal"
-                  pattern="[0-9]*[.,]?[0-9]*"
-                  step="0.5"
-                  min="0"
+                <NumberInput
+                  step={step}
+                  min={0}
+                  mode="decimal"
                   value={p.value}
                   onChange={(e) => onEntryChange(i, e.target.value)}
                   className="h-7 text-center px-1 w-[6.5rem] sm:w-[7.5rem]"

--- a/components/sets/SetList.tsx
+++ b/components/sets/SetList.tsx
@@ -1,6 +1,6 @@
 // components/sets/SetList.tsx
 import * as React from "react";
-import { Input } from "../ui/input";
+import { NumberInput } from "../ui/number-input";
 import { TactileButton } from "../TactileButton";
 import { X, Plus, Trash2 } from "lucide-react";
 
@@ -129,29 +129,26 @@ const SetList: React.FC<SetListProps> = ({
                 {it.order}
               </span>
 
-              <Input
-                type="tel"
-                inputMode="numeric"
-                pattern="[0-9]*"
+              <NumberInput
+                mode="numeric"
+                step={1}
+                min={0}
                 value={it.reps ?? "0"}
                 onFocus={onFocusScroll}
                 onChange={(e) => onChange?.(it.key, "reps", e.target.value)}
                 disabled={readOnly}
-                className={`bg-input-background border-border text-foreground text-center h-10 md:h-8 rounded-md focus:border-warm-sage focus:ring-warm-sage/20 text-sm ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
-                min="0"
+                className={`bg-input-background border-border text-foreground text-center h-10 md:h-8 rounded-md focus:border-warm-sage/20 text-sm ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
               />
 
-              <Input
-                type="number"
-                inputMode="decimal"
-                pattern="[0-9]*[.,]?[0-9]*"
-                step="0.5"
+              <NumberInput
+                mode="decimal"
+                step={0.5}
+                min={0}
                 value={it.weight ?? "0"}
                 onFocus={onFocusScroll}
                 onChange={(e) => onChange?.(it.key, "weight", e.target.value)}
                 disabled={readOnly}
                 className={`bg-input-background border-border text-foreground text-center h-10 md:h-8 rounded-md focus:border-warm-sage/20 text-sm ${readOnly ? "opacity-50 cursor-not-allowed" : ""}`}
-                min="0"
               />
 
               {mode === "workout" ? (

--- a/components/ui/number-input.tsx
+++ b/components/ui/number-input.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+
+import { Input } from "./input";
+import { cn } from "./utils";
+
+interface NumberInputProps extends React.ComponentProps<"input"> {
+  /**
+   * Choose numeric mode. Defaults to "decimal" with a decimal-friendly pattern.
+   * Use "numeric" for integers.
+   */
+  mode?: "decimal" | "numeric";
+}
+
+function NumberInput({
+  className,
+  step,
+  min,
+  mode,
+  inputMode,
+  pattern,
+  onFocus,
+  ...props
+}: NumberInputProps) {
+  const resolvedMode = mode ?? "decimal";
+  const resolvedInputMode = inputMode ?? resolvedMode;
+  const resolvedPattern =
+    pattern ?? (resolvedMode === "numeric" ? "[0-9]*" : "[0-9]*[.,]?[0-9]*");
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.target.select();
+    onFocus?.(e);
+  };
+
+  return (
+    <Input
+      type="number"
+      inputMode={resolvedInputMode}
+      pattern={resolvedPattern}
+      step={step}
+      min={min}
+      className={cn(className)}
+      onFocus={handleFocus}
+      {...props}
+    />
+  );
+}
+
+export { NumberInput };


### PR DESCRIPTION
## Summary
- add `NumberInput` wrapper to consolidate decimal and integer input configuration
- require explicit step/min/mode values in measurement and set components
- auto-select number field text on focus for faster editing

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1360ba548321bd9fea449025af92