### PR TITLE
feat: add paginated exercise fetch with caching

### DIFF
--- a/supabase/indexes.sql
+++ b/supabase/indexes.sql
@@ -1,0 +1,4 @@
+-- Indexing for exercises table to optimize search and filtering
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS exercises_name_trgm_idx ON exercises USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS exercises_muscle_group_idx ON exercises (muscle_group);

--- a/utils/supabase/cache-keys.ts
+++ b/utils/supabase/cache-keys.ts
@@ -1,10 +1,16 @@
-// All cache keys renamed to “fullCacheKey*” as requested
-
-export const fullCacheKeyExercises = () => 
-  `supabase:exercises`;
-export const fullCacheKeyExercise = (exerciseId: number) => 
+// All cache keys use the `fullCacheKey*` naming convention
+export const fullCacheKeyExercise = (exerciseId: number) =>
   `supabase:exercise:${exerciseId}`;
-export const fullCacheKeyUserRoutines = (userId: string) => 
+export const fullCacheKeyExercisesPage = (limit: number, offset: number) =>
+  `supabase:exercises:${limit}:${offset}`;
+export const fullCacheKeyExercisesMuscleGroup = (
+  group: string,
+  limit: number,
+  offset: number
+) => `supabase:exercises:muscle_group:${group}:${limit}:${offset}`;
+export const fullCacheKeyExerciseMuscleGroups =
+  "supabase:exercises:muscle_groups";
+export const fullCacheKeyUserRoutines = (userId: string) =>
   `supabase:${userId}:routines`;
 export const fullCacheKeyRoutineExercises = (userId: string, routineTemplateId: number) => 
   `supabase:${userId}:routine:${routineTemplateId}:exercises`;

--- a/utils/supabase/supabase-base.ts
+++ b/utils/supabase/supabase-base.ts
@@ -1,8 +1,10 @@
 import { localCache } from "../cache/localCache";
 import type { AuthUser } from "./supabase-types";
 import {
-  fullCacheKeyExercises,
   fullCacheKeyExercise,
+  fullCacheKeyExercisesPage,
+  fullCacheKeyExercisesMuscleGroup,
+  fullCacheKeyExerciseMuscleGroups,
   fullCacheKeyProfile,
   fullCacheKeyRoutineExercises,
   fullCacheKeyRoutineExercisesWithDetails,
@@ -280,7 +282,14 @@ export class SupabaseBase {
   }
 
   // ---------- Common keys (exported so reads/writes can use) ----------
-  protected keyExercises = () => fullCacheKeyExercises();
+  protected keyExercisesPage = (limit: number, offset: number) =>
+    fullCacheKeyExercisesPage(limit, offset);
+  protected keyExercisesMuscleGroup = (
+    group: string,
+    limit: number,
+    offset: number
+  ) => fullCacheKeyExercisesMuscleGroup(group, limit, offset);
+  protected keyExerciseMuscleGroups = () => fullCacheKeyExerciseMuscleGroups;
   protected keyExercise = (id: number) => fullCacheKeyExercise(id);
   protected keyUserRoutines = (userId: string) => fullCacheKeyUserRoutines(userId);
   protected keyRoutineExercises = (userId: string, rtId: number) => fullCacheKeyRoutineExercises(userId, rtId);


### PR DESCRIPTION
## Summary
- support paginated exercise queries with optional muscle group and search filtering
- cache exercise pages and muscle groups separately, dropping unused global cache key
- auto-load more exercises as the user scrolls using an intersection observer, with 30-item pages
- add SQL for database indexes
- preload additional exercises when scrolling within five items of the end
- keep all muscle group filters visible by fetching and caching the complete list
- avoid hook-order errors in exercise list by computing totals and observers before empty-state check
- show an error instead of "no exercises" when loading fails and clarify empty-filter message
- fetch distinct muscle groups first and wait for filters to load before requesting exercises
- fetch muscle groups via grouped query to return unique values before fetching exercises

## Testing
- `npm install`
- `npm test` *(fails: auth integration and routine CRUD integration tests)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c006a30dc08321a4e7aa8b1a0a1467