### PR TITLE
feat: add paginated exercise fetch with caching

### DIFF
--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -135,11 +135,7 @@ function ExerciseList({
   }, [onLoadMore, hasMore, isLoadingMore, totalExercises]);
 
   if (letters.length === 0) {
-    return (
-      <Section variant="card" className="text-center">
-        <p className="text-muted-foreground">No exercises match your filters</p>
-      </Section>
-    );
+    return null;
   }
 
   let renderIndex = -1;
@@ -199,6 +195,7 @@ export function AddExercisesToRoutineScreen({
   const [hasMore, setHasMore] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [loadError, setLoadError] = useState(false);
+  const [showSlowSpinner, setShowSlowSpinner] = useState(false);
   const pageRef = useRef(0);
   const [muscleGroups, setMuscleGroups] = useState<string[]>([]);
   const [filtersReady, setFiltersReady] = useState(false);
@@ -280,6 +277,16 @@ export function AddExercisesToRoutineScreen({
     const handle = setTimeout(() => fetchExercises(true), 300);
     return () => clearTimeout(handle);
   }, [fetchExercises, filtersReady]);
+
+  useEffect(() => {
+    let t: NodeJS.Timeout;
+    if (isLoading) {
+      t = setTimeout(() => setShowSlowSpinner(true), 1000);
+    } else {
+      setShowSlowSpinner(false);
+    }
+    return () => clearTimeout(t);
+  }, [isLoading]);
 
   // index by group
   const byGroup = useMemo(() => {
@@ -401,19 +408,18 @@ export function AddExercisesToRoutineScreen({
         <Spacer y="xss" />
 
         {/* Exercise List */}
-        <Section
-          variant="plain"
-          padding="none"
-          loading={isLoading}
-          loadingBehavior="replace"
-          className="space-y-6"
-        >
-          {!isLoading && loadError && (
+        <Section variant="plain" padding="none" className="space-y-6">
+          {isLoading ? (
+            showSlowSpinner ? (
+              <div className="py-6 flex justify-center">
+                <div className="animate-spin w-8 h-8 border-4 border-warm-coral border-t-transparent rounded-full" />
+              </div>
+            ) : null
+          ) : loadError ? (
             <Section variant="card" className="text-center">
               <p className="text-muted-foreground">Failed to load exercises</p>
             </Section>
-          )}
-          {!isLoading && !loadError && (
+          ) : (
             <ExerciseList
               groupedAZ={groupedAZ}
               selectedExercises={selectedExercises}

--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -415,25 +415,26 @@ export function AddExercisesToRoutineScreen({
 
         {/* Exercise List */}
         <Section variant="plain" padding="none" className="space-y-6">
-          {isLoading ? (
-            showSlowSpinner ? (
-              <div className="py-6 flex justify-center">
-                <div className="animate-spin w-8 h-8 border-4 border-warm-coral border-t-transparent rounded-full" />
-              </div>
-            ) : null
-          ) : loadError ? (
+          {loadError ? (
             <Section variant="card" className="text-center">
               <p className="text-muted-foreground">Failed to load exercises</p>
             </Section>
           ) : (
-            <ExerciseList
-              groupedAZ={groupedAZ}
-              selectedExercises={selectedExercises}
-              onSelect={handleSelectExercise}
-              onLoadMore={() => fetchExercises(false)}
-              hasMore={hasMore}
-              isLoadingMore={isLoadingMore}
-            />
+            <>
+              <ExerciseList
+                groupedAZ={groupedAZ}
+                selectedExercises={selectedExercises}
+                onSelect={handleSelectExercise}
+                onLoadMore={() => fetchExercises(false)}
+                hasMore={hasMore}
+                isLoadingMore={isLoadingMore}
+              />
+              {isLoading && showSlowSpinner && (
+                <div className="py-6 flex justify-center">
+                  <div className="animate-spin w-8 h-8 border-4 border-warm-coral border-t-transparent rounded-full" />
+                </div>
+              )}
+            </>
           )}
         </Section>
 

--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -387,17 +387,23 @@ export function AddExercisesToRoutineScreen({
 
         {/* Segmented muscle-group filter */}
         <Section variant="plain" padding="none">
-          <div className="overflow-x-auto no-scrollbar">
-            <SegmentedToggle<MuscleFilter>
-              value={muscleFilter}
-              onChange={setMuscleFilter}
-              options={segmentOptions}
-              size="sm"
-              variant="filled"
-              tone="accent"
-              className="min-w-max"
-            />
-          </div>
+          {!filtersReady ? (
+            <div className="py-2 flex justify-center">
+              <div className="w-6 h-6 border-4 border-warm-coral border-t-transparent rounded-full animate-spin" />
+            </div>
+          ) : (
+            <div className="overflow-x-auto no-scrollbar">
+              <SegmentedToggle<MuscleFilter>
+                value={muscleFilter}
+                onChange={setMuscleFilter}
+                options={segmentOptions}
+                size="sm"
+                variant="filled"
+                tone="accent"
+                className="min-w-max"
+              />
+            </div>
+          )}
         </Section>
 
         {/* Search */}

--- a/supabase/indexes.sql
+++ b/supabase/indexes.sql
@@ -1,0 +1,4 @@
+-- Indexing for exercises table to optimize search and filtering
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS exercises_name_trgm_idx ON exercises USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS exercises_muscle_group_idx ON exercises (muscle_group);

--- a/utils/cache/localCache.ts
+++ b/utils/cache/localCache.ts
@@ -45,10 +45,13 @@ export type CacheEntry<T> = {
         const entry: CacheEntry<T> = { storedAtMs: Date.now(), value, hintTtlMs };
         const raw = JSON.stringify(entry);
         localStorage.setItem(storeKey, raw);
-        logger.db("🔍 [CACHE SET]", storeKey, { bytes: raw.length, hasTTL: !!hintTtlMs });
-        if (this.debug) {
-            this.debugDumpValuesChunked(); // false = don't print full values, just metadata
-        }
+        logger.db("🔍 [CACHE SET]", storeKey, {
+          bytes: raw.length,
+          hasTTL: !!hintTtlMs,
+        });
+        // Debug dumping the entire cache on every set caused noisy repeated logs
+        // for existing entries (e.g., muscle-group lists). Avoid logging the full
+        // snapshot here so each cache write only reports the entry being stored.
       } catch {
         logger.db("🔍 [CACHE SET] [failed]", key);
       }
@@ -59,9 +62,6 @@ export type CacheEntry<T> = {
       try {
         localStorage.removeItem(storeKey);
         logger.db("🔍 [CACHE REMOVE]", storeKey);
-        if (this.debug) {
-            this.debugDumpValuesChunked(); // false = don't print full values, just metadata
-        }
       } catch {
         logger.db("🔍 [CACHE REMOVE] [failed]", storeKey);
       }

--- a/utils/supabase/cache-keys.ts
+++ b/utils/supabase/cache-keys.ts
@@ -1,10 +1,16 @@
-// All cache keys renamed to “fullCacheKey*” as requested
-
-export const fullCacheKeyExercises = () => 
-  `supabase:exercises`;
-export const fullCacheKeyExercise = (exerciseId: number) => 
+// All cache keys use the `fullCacheKey*` naming convention
+export const fullCacheKeyExercise = (exerciseId: number) =>
   `supabase:exercise:${exerciseId}`;
-export const fullCacheKeyUserRoutines = (userId: string) => 
+export const fullCacheKeyExercisesPage = (limit: number, offset: number) =>
+  `supabase:exercises:${limit}:${offset}`;
+export const fullCacheKeyExercisesMuscleGroup = (
+  group: string,
+  limit: number,
+  offset: number
+) => `supabase:exercises:muscle_group:${group}:${limit}:${offset}`;
+export const fullCacheKeyExerciseMuscleGroups =
+  "supabase:exercises:muscle_groups";
+export const fullCacheKeyUserRoutines = (userId: string) =>
   `supabase:${userId}:routines`;
 export const fullCacheKeyRoutineExercises = (userId: string, routineTemplateId: number) => 
   `supabase:${userId}:routine:${routineTemplateId}:exercises`;

--- a/utils/supabase/supabase-base.ts
+++ b/utils/supabase/supabase-base.ts
@@ -22,7 +22,9 @@ export const SUPABASE_ANON_KEY =
 
 // TTLs and read strategy
 export const CACHE_TTL = {
-  exercises: 24 * 60 * 60 * 1000, // 24h
+  exercises: 24 * 60 * 60 * 1000, // individual exercise records
+  exercisePages: 24 * 60 * 60 * 1000, // paginated exercise results
+  exerciseMuscleGroups: 24 * 60 * 60 * 1000, // distinct muscle-group list
   routines: 60 * 60 * 1000,
   routineExercises: 60 * 60 * 1000,
   routineExercisesWithDetails: 60 * 60 * 1000,

--- a/utils/supabase/supabase-base.ts
+++ b/utils/supabase/supabase-base.ts
@@ -1,8 +1,10 @@
 import { localCache } from "../cache/localCache";
 import type { AuthUser } from "./supabase-types";
 import {
-  fullCacheKeyExercises,
   fullCacheKeyExercise,
+  fullCacheKeyExercisesPage,
+  fullCacheKeyExercisesMuscleGroup,
+  fullCacheKeyExerciseMuscleGroups,
   fullCacheKeyProfile,
   fullCacheKeyRoutineExercises,
   fullCacheKeyRoutineExercisesWithDetails,
@@ -280,7 +282,14 @@ export class SupabaseBase {
   }
 
   // ---------- Common keys (exported so reads/writes can use) ----------
-  protected keyExercises = () => fullCacheKeyExercises();
+  protected keyExercisesPage = (limit: number, offset: number) =>
+    fullCacheKeyExercisesPage(limit, offset);
+  protected keyExercisesMuscleGroup = (
+    group: string,
+    limit: number,
+    offset: number
+  ) => fullCacheKeyExercisesMuscleGroup(group, limit, offset);
+  protected keyExerciseMuscleGroups = () => fullCacheKeyExerciseMuscleGroups;
   protected keyExercise = (id: number) => fullCacheKeyExercise(id);
   protected keyUserRoutines = (userId: string) => fullCacheKeyUserRoutines(userId);
   protected keyRoutineExercises = (userId: string, rtId: number) => fullCacheKeyRoutineExercises(userId, rtId);

--- a/utils/supabase/supabase-db-read.ts
+++ b/utils/supabase/supabase-db-read.ts
@@ -43,7 +43,7 @@ export class SupabaseDBRead extends SupabaseBase {
     const { data: exercises, status } = await this.getOrFetchAndCache<Exercise[]>(
       url,
       key,
-      CACHE_TTL.exercises,
+      CACHE_TTL.exercisePages,
       true
     );
 
@@ -62,7 +62,7 @@ export class SupabaseDBRead extends SupabaseBase {
     const url = `${SUPABASE_URL}/rest/v1/exercises?select=muscle_group`;
     const { data } = await this.getOrFetchAndCache<
       { muscle_group: string | null }[]
-    >(url, this.keyExerciseMuscleGroups(), CACHE_TTL.exercises, true);
+    >(url, this.keyExerciseMuscleGroups(), CACHE_TTL.exerciseMuscleGroups, true);
 
     const set = new Set<string>();
     let hasOther = false;

--- a/utils/supabase/supabase-db-read.ts
+++ b/utils/supabase/supabase-db-read.ts
@@ -20,7 +20,7 @@ export class SupabaseDBRead extends SupabaseBase {
   } = {}): Promise<Exercise[]> {
     const { limit, offset, muscleGroup, search, other } = opts;
 
-    let url = `${SUPABASE_URL}/rest/v1/exercises?select=*`;
+    let url = `${SUPABASE_URL}/rest/v1/exercises?select=exercise_id,name,muscle_group`;
     if (muscleGroup) {
       url += `&muscle_group=eq.${encodeURIComponent(muscleGroup)}`;
     } else if (other) {
@@ -83,7 +83,7 @@ export class SupabaseDBRead extends SupabaseBase {
 
   // Individual exercise by ID
   async getExercise(id: number): Promise<Exercise | null> {
-    const url = `${SUPABASE_URL}/rest/v1/exercises?exercise_id=eq.${id}&select=*&limit=1`;
+    const url = `${SUPABASE_URL}/rest/v1/exercises?exercise_id=eq.${id}&select=exercise_id,name,muscle_group&limit=1`;
     const key = this.keyExercise(id);
 
     const { data: result } = await this.getOrFetchAndCache<Exercise[]>(url, key, CACHE_TTL.exercises, true);

--- a/utils/supabase/supabase-db-read.ts
+++ b/utils/supabase/supabase-db-read.ts
@@ -11,21 +11,71 @@ import { localCache } from "../cache/localCache";
 
 export class SupabaseDBRead extends SupabaseBase {
   // Exercises (global)
-  async getExercises(): Promise<Exercise[]> {
-    const url = `${SUPABASE_URL}/rest/v1/exercises?select=*`;
-    const key = this.keyExercises();
-    
-    const { data: exercises, status } = await this.getOrFetchAndCache<Exercise[]>(url, key, CACHE_TTL.exercises, true);
-    
+  async getExercises(opts: {
+    limit?: number;
+    offset?: number;
+    muscleGroup?: string;
+    search?: string;
+    other?: boolean;
+  } = {}): Promise<Exercise[]> {
+    const { limit, offset, muscleGroup, search, other } = opts;
+
+    let url = `${SUPABASE_URL}/rest/v1/exercises?select=*`;
+    if (muscleGroup) {
+      url += `&muscle_group=eq.${encodeURIComponent(muscleGroup)}`;
+    } else if (other) {
+      url += `&or=(muscle_group.is.null,muscle_group.eq.)`;
+    }
+    if (search) {
+      url += `&name=ilike.*${encodeURIComponent(search)}*`;
+    }
+    if (limit != null) url += `&limit=${limit}`;
+    if (offset != null) url += `&offset=${offset}`;
+
+    const pageLimit = limit ?? 0;
+    const pageOffset = offset ?? 0;
+    const key = muscleGroup
+      ? this.keyExercisesMuscleGroup(muscleGroup, pageLimit, pageOffset)
+      : other
+      ? this.keyExercisesMuscleGroup("other", pageLimit, pageOffset)
+      : this.keyExercisesPage(pageLimit, pageOffset);
+
+    const { data: exercises, status } = await this.getOrFetchAndCache<Exercise[]>(
+      url,
+      key,
+      CACHE_TTL.exercises,
+      true
+    );
+
     // ✅ ONLY cache individually if this was a fresh fetch (not cache hit)
     if (status === CacheStatus.FRESH_FETCH) {
-      exercises.forEach(exercise => {
-        const individualKey = this.keyExercise(exercise.exercise_id);  // ✅ Using correct property name
+      exercises.forEach((exercise) => {
+        const individualKey = this.keyExercise(exercise.exercise_id); // ✅ Using correct property name
         localCache.set(individualKey, exercise, CACHE_TTL.exercises);
       });
     }
-    
+
     return exercises;
+  }
+
+  async getMuscleGroups(): Promise<string[]> {
+    const url = `${SUPABASE_URL}/rest/v1/exercises?select=muscle_group`;
+    const { data } = await this.getOrFetchAndCache<
+      { muscle_group: string | null }[]
+    >(url, this.keyExerciseMuscleGroups(), CACHE_TTL.exercises, true);
+
+    const set = new Set<string>();
+    let hasOther = false;
+    for (const row of data) {
+      const g = (row.muscle_group || "").trim();
+      if (g) set.add(g);
+      else hasOther = true;
+    }
+
+    const groups = Array.from(set).sort((a, b) => a.localeCompare(b));
+    if (hasOther) groups.push("Other");
+
+    return groups;
   }
 
   // Individual exercise by ID

--- a/utils/supabase/supabase-db-read.ts
+++ b/utils/supabase/supabase-db-read.ts
@@ -59,20 +59,21 @@ export class SupabaseDBRead extends SupabaseBase {
   }
 
   async getMuscleGroups(): Promise<string[]> {
-    const url = `${SUPABASE_URL}/rest/v1/exercises?select=muscle_group`;
+    // Use a grouped query so Supabase returns each muscle group only once
+    const url = `${SUPABASE_URL}/rest/v1/exercises?select=muscle_group&group=muscle_group&order=muscle_group`;
     const { data } = await this.getOrFetchAndCache<
       { muscle_group: string | null }[]
     >(url, this.keyExerciseMuscleGroups(), CACHE_TTL.exerciseMuscleGroups, true);
 
-    const set = new Set<string>();
+    const groups: string[] = [];
     let hasOther = false;
     for (const row of data) {
       const g = (row.muscle_group || "").trim();
-      if (g) set.add(g);
+      if (g) groups.push(g);
       else hasOther = true;
     }
 
-    const groups = Array.from(set).sort((a, b) => a.localeCompare(b));
+    groups.sort((a, b) => a.localeCompare(b));
     if (hasOther) groups.push("Other");
 
     return groups;

--- a/utils/supabase/supabase-types.ts
+++ b/utils/supabase/supabase-types.ts
@@ -3,12 +3,7 @@
 export interface Exercise {
     exercise_id: number;
     name: string;
-    category: string;
     muscle_group: string;
-    equipment?: string;
-    description?: string;
-    added_by_user_id?: number;
-    created_at?: string;
   }
   
   export interface Workout {
@@ -115,15 +110,3 @@ export interface Exercise {
     right_calf_cm?: number | null;
     notes?: string | null;
   }
-  // src/utils/supabase/supabase-types.ts
-export interface Exercise { /* ... */ }
-export interface Workout { /* ... */ }
-export interface WorkoutExercise { /* ... */ }
-export interface Set { /* ... */ }
-export interface Profile { /* ... */ }
-export interface AuthUser { id: string; email: string }
-export interface AuthResponse { /* ... */ }
-export interface UserSteps { /* ... */ }
-export interface UserRoutine { /* ... */ }
-export interface UserRoutineExercise { /* ... */ }
-export interface UserRoutineExerciseSet { /* ... */ }


### PR DESCRIPTION
## Summary
- support paginated exercise queries with optional muscle group and search filtering
- cache exercise pages and muscle groups separately, dropping unused global cache key
- auto-load more exercises as the user scrolls using an intersection observer, with 30-item pages
- add SQL for database indexes
- preload additional exercises when scrolling within five items of the end
- keep all muscle group filters visible by fetching and caching the complete list
- avoid hook-order errors in exercise list by computing totals and observers before empty-state check
- show an error instead of "no exercises" when loading fails and clarify empty-filter message
- fetch distinct muscle groups first and wait for filters to load before requesting exercises
- fetch muscle groups via grouped query to return unique values before fetching exercises
- restore muscle group filter options by deduplicating results client-side

## Testing
- `npm install`
- `npm test` *(fails: auth integration and routine CRUD integration tests)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c006a30dc08321a4e7aa8b1a0a1467