### PR TITLE
Add reusable loading screen for exercise loading

### DIFF
--- a/components/LoadingPage.tsx
+++ b/components/LoadingPage.tsx
@@ -1,0 +1,23 @@
+import { AppScreen } from "./layouts";
+
+export function LoadingSpinner({ className = "w-8 h-8" }: { className?: string }) {
+  return (
+    <div
+      className={[
+        "animate-spin rounded-full border-2 border-warm-coral border-t-transparent",
+        className,
+      ].join(" ")}
+    />
+  );
+}
+
+export default function LoadingPage({ message = "Loading..." }: { message?: string }) {
+  return (
+    <AppScreen padContent={false} className="grid place-items-center">
+      <div className="flex flex-col items-center gap-3 text-warm-brown/70">
+        <LoadingSpinner className="w-10 h-10 border-4" />
+        {message ? <span className="text-sm">{message}</span> : null}
+      </div>
+    </AppScreen>
+  );
+}

--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -12,6 +12,7 @@ import { BottomNavigation } from "../BottomNavigation";
 import { logger } from "../../utils/logging";
 import { performanceTimer } from "../../utils/performanceTimer";
 import ListItem from "../ui/ListItem";
+import LoadingPage from "../LoadingPage";
 
 interface AddExercisesToRoutineScreenProps {
   routineId?: number;
@@ -209,6 +210,10 @@ export function AddExercisesToRoutineScreen({
     };
   }, []);
 
+  if (isLoading) {
+    return <LoadingPage message="Loading exercises..." />;
+  }
+
   // unique muscle groups
   const muscleGroups = useMemo(() => {
     const s = new Set<string>();
@@ -339,20 +344,12 @@ export function AddExercisesToRoutineScreen({
         <Spacer y="xss" />
 
         {/* Exercise List */}
-        <Section
-          variant="plain"
-          padding="none"
-          loading={isLoading}
-          loadingBehavior="replace"
-          className="space-y-6"
-        >
-          {!isLoading && (
-            <ExerciseList
-              groupedAZ={groupedAZ}
-              selectedExercises={selectedExercises}
-              onSelect={handleSelectExercise}
-            />
-          )}
+        <Section variant="plain" padding="none" className="space-y-6">
+          <ExerciseList
+            groupedAZ={groupedAZ}
+            selectedExercises={selectedExercises}
+            onSelect={handleSelectExercise}
+          />
         </Section>
 
         <Spacer y="xl" />


### PR DESCRIPTION
## Summary
- create generic `LoadingPage` with centered spinner
- show `LoadingPage` before exercise list loads in `AddExercisesToRoutineScreen`

## Testing
- `npm test` *(fails: Supabase API integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c05216b4832187dad9205dc725a6