### PR TITLE
Auto-dismiss keyboard on scroll in AddExercises screen

### DIFF
--- a/components/layouts/AppScreen.tsx
+++ b/components/layouts/AppScreen.tsx
@@ -41,6 +41,7 @@ export type AppScreenProps = React.PropsWithChildren<{
   contentGuttersPreset?: "none" | "compact" | "responsive";
   contentBottomPaddingClassName?: string;
   headerInScrollArea?: boolean;
+  onScroll?: React.UIEventHandler<HTMLDivElement>;
 }>;
 
 const cx = (...xs: Array<string | undefined | null | false>) =>
@@ -79,6 +80,7 @@ export default function AppScreen({
 
   children,
   headerInScrollArea = false,
+  onScroll,
 }: AppScreenProps) {
   // Single global provider of --app-kb-inset / --kb-inset / --keyboard-inset
   useKeyboardInset();
@@ -191,7 +193,10 @@ export default function AppScreen({
       {header && !headerInScrollArea ? renderHeaderShell() : null}
 
       {/* Scroll area */}
-      <div className={cx("flex-1 min-h-0 overflow-y-auto w-full", scrollAreaClassName)}>
+      <div
+        className={cx("flex-1 min-h-0 overflow-y-auto w-full", scrollAreaClassName)}
+        onScroll={onScroll}
+      >
         {header && headerInScrollArea ? renderHeaderShell() : null}
 
         <div

--- a/components/screens/AddExercisesToRoutineScreen.tsx
+++ b/components/screens/AddExercisesToRoutineScreen.tsx
@@ -12,6 +12,7 @@ import { BottomNavigation } from "../BottomNavigation";
 import { logger } from "../../utils/logging";
 import { performanceTimer } from "../../utils/performanceTimer";
 import ListItem from "../ui/ListItem";
+import { useKeyboardVisible } from "../../hooks/useKeyboardVisible";
 
 interface AddExercisesToRoutineScreenProps {
   routineId?: number;
@@ -185,6 +186,13 @@ export function AddExercisesToRoutineScreen({
   isFromExerciseSetup = true,
 }: AddExercisesToRoutineScreenProps) {
   const { userToken } = useAuth();
+  const keyboardVisible = useKeyboardVisible();
+
+  const handleScroll = useCallback(() => {
+    if (keyboardVisible) {
+      (document.activeElement as HTMLElement | null)?.blur();
+    }
+  }, [keyboardVisible]);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedFilter, setSelectedFilter] = useState<MuscleFilter>("all");
@@ -395,6 +403,7 @@ export function AddExercisesToRoutineScreen({
       }
       bottomBarSticky
       contentClassName=""
+      onScroll={handleScroll}
     >
       <Stack gap="fluid">
         <Spacer y="xss" />


### PR DESCRIPTION
## Summary
- allow AppScreen to accept onScroll handler and pass to scroll container
- dismiss active input when scrolling on AddExercisesToRoutineScreen to close keyboard

## Testing
- `npm test` *(fails: authentication integration and routine CRUD tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c62ca3f08321a91a06066813da0c