### PR TITLE
Align measurement and exercise card styling

### DIFF
--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -57,10 +57,12 @@ export default function MeasurementCard({
 
   return (
     <ExpandingCard
-      variant="solid"
-      size="lg"
+      variant="plain"
+      size="md"
       expanded={expanded}
       onToggle={() => setExpanded((v) => !v)}
+      className="w-full rounded-2xl border border-border card-modern shadow-xl hover:shadow-xl transition-all text-left"
+      style={{ border: "2px solid var(--border)" }}
       /* 50% title area */
       title={
         <div className="min-w-0 flex-[0_0_50%]">

--- a/components/ui/ExpandingCard.tsx
+++ b/components/ui/ExpandingCard.tsx
@@ -26,6 +26,7 @@ type BaseProps = {
   disableChevron?: boolean;
   disabled?: boolean;
   transition?: Transition;
+  style?: React.CSSProperties;
 };
 
 // 👇 This ensures JSX `children` is always accepted.
@@ -60,7 +61,8 @@ export default function ExpandingCard({
   size = "md",
   disableChevron = false,
   disabled = false,
-  transition = {duration: 0.3}
+  transition = {duration: 0.3},
+  style,
 }: Props) {
   const bodyId = React.useId();
 
@@ -69,6 +71,7 @@ export default function ExpandingCard({
       layout
       initial={false}
       transition={transition}
+      style={style}
       className={[
         containerByVariant[variant],
         expanded ? "ring-1 ring-border" : "",


### PR DESCRIPTION
## Summary
- Restyle body measurement cards to use the modern card look for consistency with exercise setup
- Allow ExpandingCard to accept a `style` prop so callers can customize borders

## Testing
- `npm test` *(fails: Real Authentication Integration Tests and Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68c45bcca9cc8321ac8bc3a0cecc1fa0