### PR TITLE
Refactor ListItem props for flexible DOM usage

### DIFF
--- a/components/ui/ListItem.tsx
+++ b/components/ui/ListItem.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import { MoreVertical, ChevronDown } from "lucide-react";
 
-interface ListItemProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    React.ButtonHTMLAttributes<HTMLButtonElement> {
+type BaseListItemProps = {
   /** Render as a regular div (default) or button for full-row actions */
   as?: "div" | "button";
   leading?: React.ReactNode;
@@ -23,7 +21,17 @@ interface ListItemProps
   /** Rotate the chevron 180 degrees when true */
   rightIconRotated?: boolean;
   onRightIconClick?: (e: React.MouseEvent) => void;
-}
+  /** Additional custom classes applied to the root element */
+  className?: string;
+};
+
+type DivListItemProps = BaseListItemProps &
+  React.HTMLAttributes<HTMLDivElement> & { as?: "div" };
+
+type ButtonListItemProps = BaseListItemProps &
+  React.ButtonHTMLAttributes<HTMLButtonElement> & { as: "button" };
+
+type ListItemProps = DivListItemProps | ButtonListItemProps;
 
 export default function ListItem({
   as = "div",
@@ -46,10 +54,10 @@ export default function ListItem({
   const pyClass = hasSub ? "py-4" : "py-3";
   const baseInteractive =
     as === "button" ? "w-full text-left focus:outline-none" : "";
-  const Component = as === "button" ? "button" : "div";
+  const Component: any = as === "button" ? "button" : "div";
 
   return (
-    <Component className={`flex items-center gap-3 ${pyClass} ${baseInteractive} ${className}`} {...rest}>
+    <Component className={`flex items-center gap-3 ${pyClass} ${baseInteractive} ${className}`} {...(rest as any)}>
       {leading && (
         <div className={`shrink-0 ${leadingClassName}`}>{leading}</div>
       )}

--- a/utils/safe-area.ts
+++ b/utils/safe-area.ts
@@ -32,7 +32,8 @@ export function detectAndApplySafeArea() {
 
 function applyManualSafeArea() {
   const isIPhone = /iPhone/i.test(navigator.userAgent);
-  const isStandalone = window.navigator.standalone === true;
+  // `navigator.standalone` is a non-standard iOS Safari property
+  const isStandalone = (window.navigator as any).standalone === true;
   const isFullscreen = window.matchMedia('(display-mode: standalone)').matches;
   
   if (isIPhone && (isStandalone || isFullscreen)) {


### PR DESCRIPTION
## Summary
- Replace conflicting interface inheritance in `ListItem` with union of div and button attributes
- Handle non-standard `navigator.standalone` property when detecting safe area

## Testing
- `npm test` *(fails: Real Authentication Integration Tests and Supabase API Routine CRUD Integration)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: multiple type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c55f89cb448321ba743d956babf10c