### PR TITLE
Add landing image to auth screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+public/Workout/Images/*
+!public/Workout/Images/.gitkeep

--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -56,18 +56,25 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
       padHeader={false}
       padBottomBar={false}
       className="bg-gradient-to-br from-soft-gray via-background to-warm-cream/30"
-      scrollAreaClassName="grid place-items-center"
+      scrollAreaClassName="flex min-h-[100dvh]"
       bottomBar={bottomBar}
       contentClassName=""
       maxContent="responsive"
     >
-      <Card
-        className="
-          w-full
-          bg-card/80 backdrop-blur-sm border-border
-          shadow-soft
-        "
-      >
+      <img
+        src="/Workout/Images/LandingPage.png"
+        alt="Workout graphic"
+        className="hidden md:block w-1/2 object-cover"
+      />
+
+      <div className="flex flex-1 items-center justify-center p-4">
+        <Card
+          className="
+            w-full max-w-md
+            bg-card/80 backdrop-blur-sm border-border
+            shadow-soft
+          "
+        >
         <CardHeader className="text-center pb-6">
           <Stack gap="md">
             <div className="w-16 h-16 rounded-2xl gradient-primary flex items-center justify-center mx-auto">
@@ -170,6 +177,7 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
           </Stack>
         </CardContent>
       </Card>
+      </div>
     </AppScreen>
   );
 }

--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -56,9 +56,8 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
       padHeader={false}
       padBottomBar={false}
       className="bg-gradient-to-br from-soft-gray via-background to-warm-cream/30"
-      scrollAreaClassName="flex min-h-[100dvh]"
       bottomBar={bottomBar}
-      contentClassName=""
+      contentClassName="flex min-h-[100dvh]"
       maxContent="responsive"
     >
       <img

--- a/components/screens/SignUpScreen.tsx
+++ b/components/screens/SignUpScreen.tsx
@@ -102,12 +102,10 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
       padBottomBar={false}
       // Keep your gradient background
       className="bg-gradient-to-br from-soft-gray via-background to-warm-cream/30"
-      // Use flex layout to display image beside form on larger screens
-      scrollAreaClassName="flex min-h-[100dvh]"
       // Slightly narrower max width than default for auth flows
       maxContent="responsive"
       bottomBar={bottomBar}
-      contentClassName=""
+      contentClassName="flex min-h-[100dvh]"
     >
       <img
         src="/Workout/Images/LandingPage.png"

--- a/components/screens/SignUpScreen.tsx
+++ b/components/screens/SignUpScreen.tsx
@@ -102,13 +102,19 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
       padBottomBar={false}
       // Keep your gradient background
       className="bg-gradient-to-br from-soft-gray via-background to-warm-cream/30"
-      // Center the card; allow the page (not the card) to manage the primary scroll
-      scrollAreaClassName="grid place-items-center"
+      // Use flex layout to display image beside form on larger screens
+      scrollAreaClassName="flex min-h-[100dvh]"
       // Slightly narrower max width than default for auth flows
       maxContent="responsive"
       bottomBar={bottomBar}
       contentClassName=""
     >
+      <img
+        src="/Workout/Images/LandingPage.png"
+        alt="Workout graphic"
+        className="hidden md:block w-1/2 object-cover"
+      />
+      <div className="flex flex-1 items-center justify-center p-4">
       <Card
         className="
           w-full max-w-md
@@ -252,6 +258,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
           </Stack>
         </CardContent>
       </Card>
+      </div>
     </AppScreen>
   );
 }


### PR DESCRIPTION
## Summary
- display landing page image beside sign-in form
- show the same image on sign-up screen
- remove bundled landing image file and ignore local copies

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68c56bded6a0832181998d9cf1072d82