### PR TITLE
feat: add full-screen background for auth screens

### DIFF
--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -55,21 +55,14 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
     <AppScreen
       padHeader={false}
       padBottomBar={false}
-      className="bg-gradient-to-br from-soft-gray via-background to-warm-cream/30"
+      disableSafeArea
+      backgroundImageSrc="/Workout/Images/LandingPage.png"
+      backgroundOverlayClassName="bg-black/50"
       bottomBar={bottomBar}
       contentClassName="flex min-h-[100dvh]"
       maxContent="responsive"
     >
-      <img
-        src="/Workout/Images/LandingPage.png"
-        alt="Workout graphic"
-        className="hidden md:block w-1/2 object-cover"
-        style={{
-          border: "2px solid red",
-        }}
-      />
-
-       <div className="flex flex-1 items-center justify-center p-4">
+      <div className="flex flex-1 items-center justify-center p-4">
         <Card
           className="
             w-full max-w-md

--- a/components/screens/SignUpScreen.tsx
+++ b/components/screens/SignUpScreen.tsx
@@ -100,18 +100,14 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
       // Auth screen: no header / bottom bar
       padHeader={false}
       padBottomBar={false}
-      // Keep your gradient background
-      className="bg-gradient-to-br from-soft-gray via-background to-warm-cream/30"
+      disableSafeArea
+      backgroundImageSrc="/Workout/Images/LandingPage.png"
+      backgroundOverlayClassName="bg-black/50"
       // Slightly narrower max width than default for auth flows
       maxContent="responsive"
       bottomBar={bottomBar}
       contentClassName="flex min-h-[100dvh]"
     >
-      <img
-        src="/Workout/Images/LandingPage.png"
-        alt="Workout graphic"
-        className="hidden md:block w-1/2 object-cover"
-      />
       <div className="flex flex-1 items-center justify-center p-4">
       <Card
         className="


### PR DESCRIPTION
## Summary
- support optional background image and safe-area toggle in `AppScreen`
- show landing page image behind sign-in and sign-up screens

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68c58ae29470832197dd3f28876fef23