### PR TITLE
Allow SignIn backgrounds to extend into safe areas

### DIFF
--- a/components/layouts/AppScreen.tsx
+++ b/components/layouts/AppScreen.tsx
@@ -195,8 +195,10 @@ export default function AppScreen({
         className
       )}
       style={{
-        paddingLeft: disableSafeArea ? undefined : "max(env(safe-area-inset-left), 0px)",
-        paddingRight: disableSafeArea ? undefined : "max(env(safe-area-inset-right), 0px)",
+        paddingLeft: disableSafeArea ? 0 : "max(env(safe-area-inset-left), 0px)",
+        paddingRight: disableSafeArea ? 0 : "max(env(safe-area-inset-right), 0px)",
+        paddingTop: disableSafeArea ? 0 : undefined,
+        paddingBottom: disableSafeArea ? 0 : undefined,
       }}
     >
       {backgroundImageSrc && (


### PR DESCRIPTION
## Summary
- Ensure AppScreen zeroes out all side paddings when `disableSafeArea` is set

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68c5966880c48321a37f4a79cc459040