### PR TITLE
Add welcome landing screen for authentication

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -34,6 +34,7 @@ function AppContent() {
     handleAuthSuccess,
     navigateToSignUp,
     navigateToSignIn,
+    navigateToWelcome,
     handleTabChange,
     showCreateRoutine,
     showEditMeasurements,
@@ -88,6 +89,7 @@ function AppContent() {
           onAuthSuccess={(token, refreshToken) => handleAuthSuccess(token, refreshToken, setUserToken)}
           onNavigateToSignUp={navigateToSignUp}
           onNavigateToSignIn={navigateToSignIn}
+          onNavigateToWelcome={navigateToWelcome}
           onCreateRoutine={showCreateRoutine}
           onEditMeasurements={showEditMeasurements}
           onRoutineCreated={handleRoutineCreated}

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -8,6 +8,7 @@ import { ProgressScreen } from "./screens/ProgressScreen";
 import { ProfileScreen } from "./screens/ProfileScreen";
 import { SignInScreen } from "./screens/SignInScreen";
 import { SignUpScreen } from "./screens/SignUpScreen";
+import { WelcomeScreen } from "./screens/WelcomeScreen";
 
 import { AppView } from "../utils/navigation";
 import { Exercise } from "../utils/supabase/supabase-api";
@@ -93,7 +94,12 @@ export function AppRouter({
 }: AppRouterProps) {
   logger.debug(`🔍 [DBG] CURRENT SCREEN: ${currentView.toUpperCase()}`);
 
-  if (!isAuthenticated || currentView === "signin" || currentView === "signup") {
+  if (
+    !isAuthenticated ||
+    currentView === "signin" ||
+    currentView === "signup" ||
+    currentView === "welcome"
+  ) {
     if (currentView === "signup") {
       return (
         <SignUpScreen
@@ -103,10 +109,19 @@ export function AppRouter({
         />
       );
     }
+    if (currentView === "signin") {
+      return (
+        <SignInScreen
+          onAuthSuccess={onAuthSuccess}
+          onNavigateToSignUp={onNavigateToSignUp}
+          bottomBar={bottomBar}
+        />
+      );
+    }
     return (
-      <SignInScreen
-        onAuthSuccess={onAuthSuccess}
+      <WelcomeScreen
         onNavigateToSignUp={onNavigateToSignUp}
+        onNavigateToSignIn={onNavigateToSignIn}
         bottomBar={bottomBar}
       />
     );

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -32,6 +32,7 @@ interface AppRouterProps {
   onAuthSuccess: (token: string, refreshToken: string) => void;
   onNavigateToSignUp: () => void;
   onNavigateToSignIn: () => void;
+  onNavigateToWelcome: () => void;
 
   onCreateRoutine: () => void;
   onEditMeasurements: () => void;
@@ -72,6 +73,7 @@ export function AppRouter({
   onAuthSuccess,
   onNavigateToSignUp,
   onNavigateToSignIn,
+  onNavigateToWelcome,
 
   onCreateRoutine,
   onEditMeasurements,
@@ -105,6 +107,7 @@ export function AppRouter({
         <SignUpScreen
           onAuthSuccess={onAuthSuccess}
           onNavigateToSignIn={onNavigateToSignIn}
+          onNavigateToWelcome={onNavigateToWelcome}
           bottomBar={bottomBar}
         />
       );
@@ -114,6 +117,7 @@ export function AppRouter({
         <SignInScreen
           onAuthSuccess={onAuthSuccess}
           onNavigateToSignUp={onNavigateToSignUp}
+          onNavigateToWelcome={onNavigateToWelcome}
           bottomBar={bottomBar}
         />
       );

--- a/components/layouts/AppScreen.tsx
+++ b/components/layouts/AppScreen.tsx
@@ -205,7 +205,7 @@ export default function AppScreen({
     >
       {/* Background Image */}
       {backgroundImageSrc && (
-        <div className="absolute inset-0 z-0">
+        <div className="absolute inset-0 -z-10">
           <img
             src={backgroundImageSrc}
             alt=""

--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -66,7 +66,7 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, onNavigateToWe
     >
       <button
         onClick={onNavigateToWelcome}
-        className="text-white p-4 self-start"
+        className="text-blue-500 text-2xl p-4 self-start"
       >
         &lt; Back
       </button>

--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -13,10 +13,11 @@ import { logger } from "../../utils/logging";
 interface SignInScreenProps {
   onAuthSuccess: (token: string, refreshToken: string) => void;
   onNavigateToSignUp: () => void;
+  onNavigateToWelcome: () => void;
   bottomBar?: React.ReactNode;
 }
 
-export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: SignInScreenProps) {
+export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, onNavigateToWelcome, bottomBar }: SignInScreenProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -58,18 +59,25 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
       disableSafeArea={true}
       backgroundImageSrc="/Workout/Images/LandingPage.png"
       backgroundOverlayClassName="bg-black/40"
-      scrollAreaClassName="grid place-items-center"
+      scrollAreaClassName="flex flex-col"
       bottomBar={bottomBar}
       contentClassName=""
       maxContent="responsive"
     >
-      <Card
-        className="
-          w-full
-          bg-card/80 backdrop-blur-sm border-border
-          shadow-soft
-        "
+      <button
+        onClick={onNavigateToWelcome}
+        className="text-white p-4 self-start"
       >
+        &lt; Back
+      </button>
+      <div className="flex-1 flex items-center justify-center">
+        <Card
+          className="
+            w-full
+            bg-card/80 backdrop-blur-sm border-border
+            shadow-soft
+          "
+        >
         <CardHeader className="text-center pb-6">
           <Stack gap="md">
             <div className="w-16 h-16 rounded-2xl gradient-primary flex items-center justify-center mx-auto">
@@ -171,7 +179,8 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, bottomBar }: S
             <Spacer y="xs" />
           </Stack>
         </CardContent>
-      </Card>
+        </Card>
+      </div>
     </AppScreen>
   );
 }

--- a/components/screens/SignUpScreen.tsx
+++ b/components/screens/SignUpScreen.tsx
@@ -9,10 +9,11 @@ import { AppScreen, Stack, Spacer } from "../layouts";
 interface SignUpScreenProps {
   onAuthSuccess: (token: string, refreshToken: string) => void;
   onNavigateToSignIn: () => void;
+  onNavigateToWelcome: () => void;
   bottomBar?: React.ReactNode;
 }
 
-export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: SignUpScreenProps) {
+export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, onNavigateToWelcome, bottomBar }: SignUpScreenProps) {
   // Keyboard-aware insets (updates --kb-inset)
 
   const [firstName, setFirstName]   = useState("");
@@ -102,20 +103,27 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
       disableSafeArea={true}
       backgroundImageSrc="/Workout/Images/LandingPage.png"
       backgroundOverlayClassName="bg-black/40"
-      scrollAreaClassName="grid place-items-center"
+      scrollAreaClassName="flex flex-col"
       maxContent="responsive"
       bottomBar={bottomBar}
       contentClassName=""
     >
-      <Card
-        className="
-          w-full max-w-md
-          bg-card/90 backdrop-blur-sm border-border
-          shadow-soft
-          max-h-[100svh] overflow-y-auto
-          pt-safe pb-safe kb-aware
-        "
+      <button
+        onClick={onNavigateToWelcome}
+        className="text-white p-4 self-start"
       >
+        &lt; Back
+      </button>
+      <div className="flex-1 flex items-center justify-center">
+        <Card
+          className="
+            w-full max-w-md
+            bg-card/90 backdrop-blur-sm border-border
+            shadow-soft
+            max-h-[100svh] overflow-y-auto
+            pt-safe pb-safe kb-aware
+          "
+        >
         <CardHeader className="text-center">
           <Stack gap="xs">
             <h1 className="text-2xl font-medium text-black">Create Account</h1>
@@ -249,7 +257,8 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, bottomBar }: S
             </div>
           </Stack>
         </CardContent>
-      </Card>
+        </Card>
+      </div>
     </AppScreen>
   );
 }

--- a/components/screens/SignUpScreen.tsx
+++ b/components/screens/SignUpScreen.tsx
@@ -110,7 +110,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, onNavigateToWe
     >
       <button
         onClick={onNavigateToWelcome}
-        className="text-white p-4 self-start"
+        className="text-blue-500 text-2xl p-4 self-start"
       >
         &lt; Back
       </button>

--- a/components/screens/WelcomeScreen.tsx
+++ b/components/screens/WelcomeScreen.tsx
@@ -27,7 +27,7 @@ export function WelcomeScreen({
     >
       <div className="flex-1 flex flex-col items-center justify-center px-4">
         <Stack gap="sm">
-          <h1 className="text-3xl font-semibold">Welcome to Strong</h1>
+          <h1 className="text-3xl font-semibold">Welcome to WorkItOut</h1>
           <p className="text-base">Your workout journey starts here.</p>
         </Stack>
       </div>

--- a/components/screens/WelcomeScreen.tsx
+++ b/components/screens/WelcomeScreen.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from "react";
+import { TactileButton } from "../TactileButton";
+import { AppScreen, Stack, Spacer } from "../layouts";
+
+interface WelcomeScreenProps {
+  onNavigateToSignUp: () => void;
+  onNavigateToSignIn: () => void;
+  bottomBar?: ReactNode;
+}
+
+export function WelcomeScreen({
+  onNavigateToSignUp,
+  onNavigateToSignIn,
+  bottomBar,
+}: WelcomeScreenProps) {
+  return (
+    <AppScreen
+      padHeader={false}
+      padBottomBar={false}
+      disableSafeArea={true}
+      backgroundImageSrc="/Workout/Images/LandingPage.png"
+      backgroundOverlayClassName="bg-black/50"
+      scrollAreaClassName="flex flex-col"
+      contentClassName="flex-1 flex flex-col justify-between text-center text-white"
+      bottomBar={bottomBar}
+      maxContent="responsive"
+    >
+      <div className="flex-1 flex flex-col items-center justify-center px-4">
+        <Stack gap="sm">
+          <h1 className="text-3xl font-semibold">Welcome to Strong</h1>
+          <p className="text-base">Your workout journey starts here.</p>
+        </Stack>
+      </div>
+      <div className="w-full px-4 pb-8 space-y-4">
+        <TactileButton className="w-full" onClick={onNavigateToSignUp}>
+          Sign Up
+        </TactileButton>
+        <TactileButton
+          variant="secondary"
+          className="w-full"
+          onClick={onNavigateToSignIn}
+        >
+          Sign In
+        </TactileButton>
+        <Spacer y="xs" />
+      </div>
+    </AppScreen>
+  );
+}
+

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -30,7 +30,7 @@ export function useAppNavigation() {
   const handleUnauthorizedError = (error: Error) => {
     if (error.message === "UNAUTHORIZED") {
       toast.error("Session expired. Please sign in.");
-      setCurrentView("signin");
+      setCurrentView("welcome");
       return true;
     }
     return false;

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -44,6 +44,7 @@ export function useAppNavigation() {
 
   const navigateToSignUp = () => setCurrentView("signup");
   const navigateToSignIn = () => setCurrentView("signin");
+  const navigateToWelcome = () => setCurrentView("welcome");
 
   const handleTabChange = (tab: "workouts" | "progress" | "profile") => {
     setActiveTab(tab);
@@ -155,6 +156,7 @@ export function useAppNavigation() {
     handleAuthSuccess,
     navigateToSignUp,
     navigateToSignIn,
+    navigateToWelcome,
     handleTabChange,
 
     showCreateRoutine,

--- a/hooks/useAuthEffects.ts
+++ b/hooks/useAuthEffects.ts
@@ -41,10 +41,18 @@ export function useAuthEffects({ currentView, setCurrentView }: UseAuthEffectsPr
     if (!authReady) return;
 
     if (!isAuthenticated) {
-      if (currentView !== "signin" && currentView !== "signup") {
-        setCurrentView("signin");
+      if (
+        currentView !== "signin" &&
+        currentView !== "signup" &&
+        currentView !== "welcome"
+      ) {
+        setCurrentView("welcome");
       }
-    } else if (currentView === "signin" || currentView === "signup") {
+    } else if (
+      currentView === "signin" ||
+      currentView === "signup" ||
+      currentView === "welcome"
+    ) {
       setCurrentView("workouts");
     }
   }, [authReady, isAuthenticated, currentView, setCurrentView]);

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,7 +1,8 @@
-export type AppView = 
+export type AppView =
+  | "welcome"
   | "signin"
   | "signup"
-  | "workouts" 
+  | "workouts"
   | "create-routine"
   | "add-exercises-to-routine"
   | "exercise-setup"
@@ -11,8 +12,9 @@ export type AppView =
   | "profile";
 
 export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
+  "welcome",
   "signin",
-  "signup", 
+  "signup",
   "create-routine",
   "add-exercises-to-routine",
   "exercise-setup",


### PR DESCRIPTION
## Summary
- introduce WelcomeScreen using existing landing image with sign up and sign in buttons
- extend navigation and auth flow to include new welcome view

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dd37f3688321872dc18e7d9b596f