### PR TITLE
Remove default TactileButton styling so callers supply classes

### DIFF
--- a/components/BottomNavigationButton.tsx
+++ b/components/BottomNavigationButton.tsx
@@ -19,7 +19,7 @@ export function BottomNavigationButton({
       variant={variant}
       size="sm"
       className={cn(
-        "px-6 md:px-8 py-3 font-medium border-0 transition-all disabled:opacity-50 disabled:cursor-not-allowed",
+        "px-6 md:px-8 py-3 font-medium border-0 rounded-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed",
         className
       )}
       {...props}

--- a/components/TactileButton.tsx
+++ b/components/TactileButton.tsx
@@ -3,7 +3,7 @@ import { ButtonHTMLAttributes, ReactNode } from "react";
 
 interface TactileButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
-  variant?: "primary" | "secondary" | "sage" | "peach" | "mint";
+  variant?: "primary" | "secondary" | "sage" | "peach" | "mint" | "ghost";
   size?: "sm" | "md" | "lg";
   className?: string;
 }
@@ -15,14 +15,13 @@ export function TactileButton({
   className,
   ...props 
 }: TactileButtonProps) {
-  const baseClasses = "btn-tactile rounded-xl border-0 font-medium";
-  
   const variantClasses = {
-    primary: "bg-primary hover:bg-primary-hover text-black",
-    secondary: "bg-warm-cream hover:bg-warm-cream/90 text-black",
-    sage: "bg-warm-sage hover:bg-warm-sage/90 text-black btn-tactile-sage",
-    peach: "bg-warm-peach hover:bg-warm-peach/90 text-black",
-    mint: "bg-warm-mint hover:bg-warm-mint/90 text-black"
+    primary: "btn-tactile bg-primary hover:bg-primary-hover text-black",
+    secondary: "btn-tactile bg-warm-cream hover:bg-warm-cream/90 text-black",
+    sage: "btn-tactile bg-warm-sage hover:bg-warm-sage/90 text-black btn-tactile-sage",
+    peach: "btn-tactile bg-warm-peach hover:bg-warm-peach/90 text-black",
+    mint: "btn-tactile bg-warm-mint hover:bg-warm-mint/90 text-black",
+    ghost: "bg-transparent hover:bg-transparent text-black shadow-none hover:shadow-none active:shadow-none rounded-none transition-none hover:translate-y-0 active:translate-y-0"
   };
 
   const sizeClasses = {
@@ -34,7 +33,6 @@ export function TactileButton({
   return (
     <button
       className={cn(
-        baseClasses,
         variantClasses[variant],
         sizeClasses[size],
         className

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -246,7 +246,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
                 <TactileButton
                   key={level}
                   variant={getLogLevel() === level ? "primary" : "secondary"}
-                  className="text-sm"
+                  className="text-sm rounded-xl border-0 font-medium"
                   onClick={() => {
                     setLogLevel(level);
                     toast.success(`Log level set to: ${level}`);
@@ -268,7 +268,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           <div className="space-y-3">
             <TactileButton
               variant="secondary"
-              className="w-full flex items-center justify-center gap-2"
+              className="w-full flex items-center justify-center gap-2 rounded-xl border-0 font-medium"
             >
               <Settings size={16} />
               Settings
@@ -276,7 +276,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
 
             <TactileButton
               variant="sage"
-              className="w-full flex items-center justify-center gap-2"
+              className="w-full flex items-center justify-center gap-2 rounded-xl border-0 font-medium"
               onClick={handleSignOut}
               disabled={isSigningOut}
             >

--- a/components/screens/SignInScreen.tsx
+++ b/components/screens/SignInScreen.tsx
@@ -135,7 +135,7 @@ export function SignInScreen({ onAuthSuccess, onNavigateToSignUp, onNavigateToWe
 
               <TactileButton
                 type="submit"
-                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-black"
+                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-black rounded-xl border-0 font-medium"
                 disabled={isLoading}
               >
                 {isLoading ? (

--- a/components/screens/SignUpScreen.tsx
+++ b/components/screens/SignUpScreen.tsx
@@ -228,7 +228,7 @@ export function SignUpScreen({ onAuthSuccess, onNavigateToSignIn, onNavigateToWe
               <TactileButton
                 type="submit"
                 disabled={disabledSubmit}
-                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-black disabled:opacity-60 disabled:cursor-not-allowed"
+                className="w-full bg-gradient-to-r from-warm-coral to-warm-peach text-black rounded-xl border-0 font-medium disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {isLoading ? (
                   <div className="flex items-center justify-center gap-2">

--- a/components/screens/WelcomeScreen.tsx
+++ b/components/screens/WelcomeScreen.tsx
@@ -32,12 +32,12 @@ export function WelcomeScreen({
         </Stack>
       </div>
       <div className="w-full px-4 pb-8 space-y-4">
-        <TactileButton className="w-full" onClick={onNavigateToSignUp}>
+        <TactileButton className="w-full rounded-xl border-0 font-medium" onClick={onNavigateToSignUp}>
           Sign Up
         </TactileButton>
         <TactileButton
           variant="secondary"
-          className="w-full"
+          className="w-full rounded-xl border-0 font-medium"
           onClick={onNavigateToSignIn}
         >
           Sign In

--- a/components/sets/ExerciseSetEditorCard.tsx
+++ b/components/sets/ExerciseSetEditorCard.tsx
@@ -84,7 +84,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
             size="sm"
             onClick={onCancel}
             disabled={disabled}
-            className={`p-3 h-auto bg-card/70 border-destructive-light text-black hover:bg-destructive-light btn-tactile ${
+            className={`p-3 h-auto bg-card/70 border-destructive-light text-black hover:bg-destructive-light btn-tactile rounded-xl font-medium ${
               disabled ? "opacity-50 cursor-not-allowed" : ""
             }`}
             title="Cancel"

--- a/components/sets/SetList.tsx
+++ b/components/sets/SetList.tsx
@@ -187,7 +187,8 @@ const SetList: React.FC<SetListProps> = ({
           {onAdd ? (
             <TactileButton
               onClick={onAdd}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg btn-tactile bg-card/70 border-border text-black hover:bg-card font-medium"
+              variant="primary"
+              className="flex items-center gap-2 px-4 py-2 rounded-lg font-medium"
               disabled={isDisabled}
               title={
                 isDisabled

--- a/components/sets/SetList.tsx
+++ b/components/sets/SetList.tsx
@@ -162,10 +162,11 @@ const SetList: React.FC<SetListProps> = ({
                 </div>
               ) : canRemove ? (
                 <TactileButton
-                  variant="secondary"
+                  type="button"
+                  variant="ghost"
                   size="sm"
                   onClick={() => onRemove?.(it.key)}
-                  className="p-1 h-auto bg-destructive-light text-black hover:bg-destructive ml-auto"
+                  className="p-1 h-auto ml-auto"
                   title="Remove this set"
                 >
                   <X size={14} />
@@ -186,7 +187,7 @@ const SetList: React.FC<SetListProps> = ({
           {onAdd ? (
             <TactileButton
               onClick={onAdd}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg btn-tactile bg-card/70 border-border text-black hover:bg-card"
+              className="flex items-center gap-2 px-4 py-2 rounded-lg btn-tactile bg-card/70 border-border text-black hover:bg-card font-medium"
               disabled={isDisabled}
               title={
                 isDisabled
@@ -212,7 +213,7 @@ const SetList: React.FC<SetListProps> = ({
               size="sm"
               onClick={onDeleteExercise}
               disabled={deleteDisabled || readOnly}
-              className={`p-2 h-auto rounded-lg ${deleteDisabled || readOnly
+              className={`p-2 h-auto rounded-lg font-medium ${deleteDisabled || readOnly
                 ? "opacity-50 cursor-not-allowed"
                 : "bg-destructive-light text-black hover:bg-destructive"
                 }`}

--- a/components/sheets/ActionSheet.tsx
+++ b/components/sheets/ActionSheet.tsx
@@ -63,7 +63,7 @@ export default function ActionSheet({
         cancelText !== null ? (
           <TactileButton
             variant="secondary"
-            className="w-full py-3"
+            className="w-full py-3 rounded-xl border-0 font-medium"
             onClick={onClose}
           >
             {cancelText}
@@ -88,7 +88,7 @@ export default function ActionSheet({
                   disabled={a.disabled}
                   variant={a.variant === "secondary" ? "secondary" : "primary"}
                   className={cn(
-                    "w-full",
+                    "w-full rounded-xl border-0 font-medium",
                     a.variant === "destructive" &&
                       "bg-destructive hover:bg-destructive/90 text-black"
                   )}

--- a/components/workout-dashboard/RoutinesList.tsx
+++ b/components/workout-dashboard/RoutinesList.tsx
@@ -54,7 +54,7 @@ export default function RoutinesList({
               variant="card"
               title="Error Loading Routines"
               actions={
-                <TactileButton onClick={reloadRoutines} variant="secondary" className="px-4 py-2 text-sm">
+                <TactileButton onClick={reloadRoutines} variant="secondary" className="px-4 py-2 text-sm rounded-xl border-0 font-medium">
                   Try Again
                 </TactileButton>
               }


### PR DESCRIPTION
## Summary
- strip default rounding/border/font from TactileButton
- update button call sites to pass base classes explicitly

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ebe1a8a08321813b32f05b2fe4bd