### PR TITLE
fix: prevent cache clearing on token refresh

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import { VIEWS_WITHOUT_BOTTOM_NAV } from "./utils/navigation";
 
 // ✅ add this (path to your boundary component)
 import ErrorBoundary from "./components/system/ErrorBoundary";
+import "./utils/appState";
 
 // App.tsx
 function AppContent() {

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -18,6 +18,7 @@ import { performanceTimer } from "../../utils/performanceTimer";
 import { loadRoutineExercisesWithSets, SETS_PREFETCH_CONCURRENCY } from "../../utils/routineLoader";
 import ListItem from "../ui/ListItem";
 import ActionSheet from "../sheets/ActionSheet";
+import { useAppStateSaver } from "../../utils/appState";
 
 // --- Journal-based persistence (simple, testable) ---
 import {
@@ -120,6 +121,24 @@ export function ExerciseSetupScreen({
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const workoutStartRef = useRef<number | null>(null);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  type SaverState = {
+    exercises: UIExercise[];
+    screenMode: ScreenMode;
+    selectedExercisesForSetup: Exercise[];
+    elapsedSeconds: number;
+  };
+
+  useAppStateSaver<SaverState>(
+    "exercise-setup",
+    { exercises, screenMode, selectedExercisesForSetup, elapsedSeconds },
+    (s) => {
+      setExercises(s.exercises ?? []);
+      setScreenMode(s.screenMode ?? initialMode);
+      setSelectedExercisesForSetup(s.selectedExercisesForSetup ?? []);
+      setElapsedSeconds(s.elapsedSeconds ?? 0);
+    }
+  );
 
   const formatHHMMSS = (totalSeconds: number) => {
     const hours = Math.floor(totalSeconds / 3600);

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -127,6 +127,9 @@ export function ExerciseSetupScreen({
     screenMode: ScreenMode;
     selectedExercisesForSetup: Exercise[];
     elapsedSeconds: number;
+    journal: ReturnType<typeof makeJournal>;
+    savedSnapshot: any[];
+    preWorkoutExercises: UIExercise[];
   };
   const restoreState = useCallback(
     (s: SaverState) => {
@@ -134,6 +137,9 @@ export function ExerciseSetupScreen({
       setScreenMode(s.screenMode ?? initialMode);
       setSelectedExercisesForSetup(s.selectedExercisesForSetup ?? []);
       setElapsedSeconds(s.elapsedSeconds ?? 0);
+      journalRef.current = s.journal ?? makeJournal();
+      savedSnapshotRef.current = s.savedSnapshot ?? [];
+      preWorkoutExercisesRef.current = s.preWorkoutExercises ?? [];
     },
     [initialMode, setSelectedExercisesForSetup]
   );
@@ -141,7 +147,15 @@ export function ExerciseSetupScreen({
   // Persist this screen's working state across app background/foreground cycles
   useAppStateSaver<SaverState>(
     "exercise-setup",
-    { exercises, screenMode, selectedExercisesForSetup, elapsedSeconds },
+    {
+      exercises,
+      screenMode,
+      selectedExercisesForSetup,
+      elapsedSeconds,
+      journal: journalRef.current,
+      savedSnapshot: savedSnapshotRef.current,
+      preWorkoutExercises: preWorkoutExercisesRef.current,
+    },
     restoreState
   );
 

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -226,6 +226,11 @@ export function ExerciseSetupScreen({
      ------------------------------------------------------------------------------------- */
   useEffect(() => {
     if (!userToken) return;
+    // If state was restored from app-state cache, skip fetching
+    if (exercises.length > 0) {
+      setLoadingSaved(false);
+      return;
+    }
     let cancelled = false;
 
     (async () => {
@@ -262,7 +267,7 @@ export function ExerciseSetupScreen({
     return () => {
       cancelled = true;
     };
-  }, [routineId, userToken]);
+  }, [routineId, userToken]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /* -------------------------------------------------------------------------------------
      Add selected exercises AFTER initial load completes

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -1,5 +1,5 @@
 // components/screens/ExerciseSetupScreen.tsx
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AppScreen, Section, ScreenHeader, Stack, Spacer } from "../layouts";
 import { BottomNavigation } from "../BottomNavigation";
@@ -128,16 +128,20 @@ export function ExerciseSetupScreen({
     selectedExercisesForSetup: Exercise[];
     elapsedSeconds: number;
   };
-
-  useAppStateSaver<SaverState>(
-    "exercise-setup",
-    { exercises, screenMode, selectedExercisesForSetup, elapsedSeconds },
-    (s) => {
+  const restoreState = useCallback(
+    (s: SaverState) => {
       setExercises(s.exercises ?? []);
       setScreenMode(s.screenMode ?? initialMode);
       setSelectedExercisesForSetup(s.selectedExercisesForSetup ?? []);
       setElapsedSeconds(s.elapsedSeconds ?? 0);
-    }
+    },
+    [initialMode, setSelectedExercisesForSetup]
+  );
+
+  useAppStateSaver<SaverState>(
+    "exercise-setup",
+    { exercises, screenMode, selectedExercisesForSetup, elapsedSeconds },
+    restoreState
   );
 
   const formatHHMMSS = (totalSeconds: number) => {

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -138,6 +138,7 @@ export function ExerciseSetupScreen({
     [initialMode, setSelectedExercisesForSetup]
   );
 
+  // Persist this screen's working state across app background/foreground cycles
   useAppStateSaver<SaverState>(
     "exercise-setup",
     { exercises, screenMode, selectedExercisesForSetup, elapsedSeconds },

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -1,0 +1,65 @@
+import { App } from '@capacitor/app';
+import { useEffect, useRef } from 'react';
+import { localCache } from './cache/localCache';
+
+interface Saver<T = unknown> {
+  key: string;
+  save: () => T;
+  restore: (value: T) => void;
+}
+
+const savers: Saver[] = [];
+
+export function registerAppStateSaver<T>(
+  key: string,
+  save: () => T,
+  restore: (value: T) => void
+) {
+  savers.push({ key, save, restore });
+  return () => {
+    const i = savers.findIndex(
+      (s) => s.key === key && s.save === save && s.restore === restore
+    );
+    if (i >= 0) savers.splice(i, 1);
+  };
+}
+
+function handleStateChange(isActive: boolean) {
+  if (!isActive) {
+    savers.forEach(({ key, save }) => {
+      try {
+        const data = save();
+        localCache.set(`appstate:${key}`, data);
+      } catch {
+        /* ignore */
+      }
+    });
+  } else {
+    savers.forEach(({ key, restore }) => {
+      const data = localCache.get(`appstate:${key}`, Number.MAX_SAFE_INTEGER);
+      if (data !== null) {
+        try {
+          restore(data);
+        } finally {
+          localCache.remove(`appstate:${key}`);
+        }
+      }
+    });
+  }
+}
+
+export function useAppStateSaver<T>(key: string, data: T, setData: (value: T) => void) {
+  const ref = useRef(data);
+  useEffect(() => {
+    ref.current = data;
+  }, [data]);
+  useEffect(() => registerAppStateSaver(key, () => ref.current, setData), [key, setData]);
+}
+
+App.addListener('appStateChange', ({ isActive }) => handleStateChange(isActive));
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () =>
+    handleStateChange(document.visibilityState === 'visible')
+  );
+}

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -53,7 +53,18 @@ export function useAppStateSaver<T>(key: string, data: T, setData: (value: T) =>
   useEffect(() => {
     ref.current = data;
   }, [data]);
-  useEffect(() => registerAppStateSaver(key, () => ref.current, setData), [key, setData]);
+  useEffect(() => {
+    const cacheKey = `appstate:${key}`;
+    const cached = localCache.get(cacheKey, Number.MAX_SAFE_INTEGER);
+    if (cached !== null) {
+      try {
+        setData(cached);
+      } finally {
+        localCache.remove(cacheKey);
+      }
+    }
+    return registerAppStateSaver(key, () => ref.current, setData);
+  }, [key, setData]);
 }
 
 App.addListener('appStateChange', ({ isActive }) => handleStateChange(isActive));

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -1,6 +1,7 @@
 import { App } from '@capacitor/app';
 import { useEffect, useRef } from 'react';
 import { localCache } from './cache/localCache';
+import { logger } from './logging';
 
 interface Saver<T = unknown> {
   key: string;
@@ -15,62 +16,148 @@ export function registerAppStateSaver<T>(
   save: () => T,
   restore: (value: T) => void
 ) {
-  savers.push({ key, save, restore });
+  logger.debug(`[APP-STATE] Registering state saver for key: ${key}`);
+  savers.push({ key, save, restore: restore as (value: unknown) => void });
+  logger.debug(`[APP-STATE] Total savers registered: ${savers.length}`);
+
   return () => {
     const i = savers.findIndex(
       (s) => s.key === key && s.save === save && s.restore === restore
     );
-    if (i >= 0) savers.splice(i, 1);
+    if (i >= 0) {
+      savers.splice(i, 1);
+      logger.debug(
+        `[APP-STATE] Unregistered state saver for key: ${key}. Remaining savers: ${savers.length}`
+      );
+    } else {
+      logger.debug(
+        `[APP-STATE] State saver not found for unregistration: ${key}`
+      );
+    }
   };
 }
 
 function handleStateChange(isActive: boolean) {
+  logger.debug(
+    `[APP-STATE] App state changed - isActive: ${isActive}, total savers: ${savers.length}`
+  );
+
   if (!isActive) {
+    logger.debug(
+      `[APP-STATE] App becoming inactive - saving state for ${savers.length} savers`
+    );
     savers.forEach(({ key, save }) => {
       try {
+        logger.debug(`[APP-STATE] Saving state for key: ${key}`);
         const data = save();
         localCache.set(`appstate:${key}`, data);
-      } catch {
-        /* ignore */
+        logger.debug(
+          `[APP-STATE] Successfully saved state for key: ${key}`,
+          data
+        );
+      } catch (error) {
+        logger.debug(
+          `[APP-STATE] Failed to save state for key: ${key}`,
+          error
+        );
       }
     });
+    logger.debug(`[APP-STATE] Completed saving all states`);
   } else {
+    logger.debug(
+      `[APP-STATE] App becoming active - restoring state for ${savers.length} savers`
+    );
     savers.forEach(({ key, restore }) => {
       const data = localCache.get(`appstate:${key}`, Number.MAX_SAFE_INTEGER);
       if (data !== null) {
         try {
+          logger.debug(`[APP-STATE] Restoring state for key: ${key}`, data);
           restore(data);
+          logger.debug(`[APP-STATE] Successfully restored state for key: ${key}`);
+        } catch (error) {
+          logger.debug(
+            `[APP-STATE] Failed to restore state for key: ${key}`,
+            error
+          );
         } finally {
           localCache.remove(`appstate:${key}`);
+          logger.debug(`[APP-STATE] Removed cached state for key: ${key}`);
         }
+      } else {
+        logger.debug(`[APP-STATE] No cached state found for key: ${key}`);
       }
     });
+    logger.debug(`[APP-STATE] Completed restoring all states`);
   }
 }
 
 export function useAppStateSaver<T>(key: string, data: T, setData: (value: T) => void) {
   const ref = useRef(data);
   useEffect(() => {
+    logger.debug(
+      `[APP-STATE] useAppStateSaver - data updated for key: ${key}`,
+      data
+    );
     ref.current = data;
-  }, [data]);
+  }, [data, key]);
   useEffect(() => {
+    logger.debug(
+      `[APP-STATE] useAppStateSaver - setting up state saver for key: ${key}`
+    );
     const cacheKey = `appstate:${key}`;
     const cached = localCache.get(cacheKey, Number.MAX_SAFE_INTEGER);
     if (cached !== null) {
       try {
+        logger.debug(
+          `[APP-STATE] Restoring cached state for key: ${key} on mount`,
+          cached
+        );
         setData(cached);
+        logger.debug(
+          `[APP-STATE] Successfully restored cached state for key: ${key} on mount`
+        );
+      } catch (error) {
+        logger.debug(
+          `[APP-STATE] Failed to restore cached state for key: ${key} on mount`,
+          error
+        );
       } finally {
         localCache.remove(cacheKey);
+        logger.debug(
+          `[APP-STATE] Removed cached state for key: ${key} on mount`
+        );
       }
+    } else {
+      logger.debug(
+        `[APP-STATE] No cached state found for key: ${key} on mount`
+      );
     }
     return registerAppStateSaver(key, () => ref.current, setData);
   }, [key, setData]);
 }
 
-App.addListener('appStateChange', ({ isActive }) => handleStateChange(isActive));
+logger.debug(`[APP-STATE] Setting up app state change listeners`);
+
+App.addListener('appStateChange', ({ isActive }) => {
+  logger.debug(
+    `[APP-STATE] Capacitor app state change event - isActive: ${isActive}`
+  );
+  handleStateChange(isActive);
+});
 
 if (typeof document !== 'undefined') {
-  document.addEventListener('visibilitychange', () =>
-    handleStateChange(document.visibilityState === 'visible')
+  logger.debug(
+    `[APP-STATE] Setting up document visibility change listener`
+  );
+  document.addEventListener('visibilitychange', () => {
+    const isVisible = document.visibilityState === 'visible';
+    logger.debug(
+      `[APP-STATE] Document visibility change event - isVisible: ${isVisible}`
+    );
+    handleStateChange(isVisible);
+  });
+} else {
+  logger.debug(
+    `[APP-STATE] Document not available - skipping visibility change listener`
   );
 }

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -10,6 +10,7 @@ interface Saver<T = unknown> {
 }
 
 const savers: Saver[] = [];
+let lastIsActive: boolean | null = null;
 
 export function registerAppStateSaver<T>(
   key: string,
@@ -38,6 +39,10 @@ export function registerAppStateSaver<T>(
 }
 
 function handleStateChange(isActive: boolean) {
+  if (lastIsActive === isActive) {
+    return;
+  }
+  lastIsActive = isActive;
   logger.info(
     `[APP-STATE] App state changed - isActive: ${isActive}, total savers: ${savers.length}`
   );

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -91,13 +91,13 @@ function handleStateChange(isActive: boolean) {
   }
 }
 
-export function useAppStateSaver<T>(key: string, data: T, setData: (value: T) => void) {
+export function useAppStateSaver<T>(
+  key: string,
+  data: T,
+  setData: (value: T) => void
+) {
   const ref = useRef(data);
   useEffect(() => {
-    logger.info(
-      `[APP-STATE] useAppStateSaver - data updated for key: ${key}`,
-      data
-    );
     ref.current = data;
   }, [data, key]);
   useEffect(() => {

--- a/utils/appState.ts
+++ b/utils/appState.ts
@@ -16,9 +16,9 @@ export function registerAppStateSaver<T>(
   save: () => T,
   restore: (value: T) => void
 ) {
-  logger.debug(`[APP-STATE] Registering state saver for key: ${key}`);
+  logger.info(`[APP-STATE] Registering state saver for key: ${key}`);
   savers.push({ key, save, restore: restore as (value: unknown) => void });
-  logger.debug(`[APP-STATE] Total savers registered: ${savers.length}`);
+  logger.info(`[APP-STATE] Total savers registered: ${savers.length}`);
 
   return () => {
     const i = savers.findIndex(
@@ -26,11 +26,11 @@ export function registerAppStateSaver<T>(
     );
     if (i >= 0) {
       savers.splice(i, 1);
-      logger.debug(
+      logger.info(
         `[APP-STATE] Unregistered state saver for key: ${key}. Remaining savers: ${savers.length}`
       );
     } else {
-      logger.debug(
+      logger.info(
         `[APP-STATE] State saver not found for unregistration: ${key}`
       );
     }
@@ -38,97 +38,97 @@ export function registerAppStateSaver<T>(
 }
 
 function handleStateChange(isActive: boolean) {
-  logger.debug(
+  logger.info(
     `[APP-STATE] App state changed - isActive: ${isActive}, total savers: ${savers.length}`
   );
 
   if (!isActive) {
-    logger.debug(
+    logger.info(
       `[APP-STATE] App becoming inactive - saving state for ${savers.length} savers`
     );
     savers.forEach(({ key, save }) => {
       try {
-        logger.debug(`[APP-STATE] Saving state for key: ${key}`);
+        logger.info(`[APP-STATE] Saving state for key: ${key}`);
         const data = save();
         localCache.set(`appstate:${key}`, data);
-        logger.debug(
+        logger.info(
           `[APP-STATE] Successfully saved state for key: ${key}`,
           data
         );
       } catch (error) {
-        logger.debug(
+        logger.info(
           `[APP-STATE] Failed to save state for key: ${key}`,
           error
         );
       }
     });
-    logger.debug(`[APP-STATE] Completed saving all states`);
+    logger.info(`[APP-STATE] Completed saving all states`);
   } else {
-    logger.debug(
+    logger.info(
       `[APP-STATE] App becoming active - restoring state for ${savers.length} savers`
     );
     savers.forEach(({ key, restore }) => {
       const data = localCache.get(`appstate:${key}`, Number.MAX_SAFE_INTEGER);
       if (data !== null) {
         try {
-          logger.debug(`[APP-STATE] Restoring state for key: ${key}`, data);
+          logger.info(`[APP-STATE] Restoring state for key: ${key}`, data);
           restore(data);
-          logger.debug(`[APP-STATE] Successfully restored state for key: ${key}`);
+          logger.info(`[APP-STATE] Successfully restored state for key: ${key}`);
         } catch (error) {
-          logger.debug(
+          logger.info(
             `[APP-STATE] Failed to restore state for key: ${key}`,
             error
           );
         } finally {
           localCache.remove(`appstate:${key}`);
-          logger.debug(`[APP-STATE] Removed cached state for key: ${key}`);
+          logger.info(`[APP-STATE] Removed cached state for key: ${key}`);
         }
       } else {
-        logger.debug(`[APP-STATE] No cached state found for key: ${key}`);
+        logger.info(`[APP-STATE] No cached state found for key: ${key}`);
       }
     });
-    logger.debug(`[APP-STATE] Completed restoring all states`);
+    logger.info(`[APP-STATE] Completed restoring all states`);
   }
 }
 
 export function useAppStateSaver<T>(key: string, data: T, setData: (value: T) => void) {
   const ref = useRef(data);
   useEffect(() => {
-    logger.debug(
+    logger.info(
       `[APP-STATE] useAppStateSaver - data updated for key: ${key}`,
       data
     );
     ref.current = data;
   }, [data, key]);
   useEffect(() => {
-    logger.debug(
+    logger.info(
       `[APP-STATE] useAppStateSaver - setting up state saver for key: ${key}`
     );
     const cacheKey = `appstate:${key}`;
     const cached = localCache.get(cacheKey, Number.MAX_SAFE_INTEGER);
     if (cached !== null) {
       try {
-        logger.debug(
+        logger.info(
           `[APP-STATE] Restoring cached state for key: ${key} on mount`,
           cached
         );
         setData(cached);
-        logger.debug(
+        logger.info(
           `[APP-STATE] Successfully restored cached state for key: ${key} on mount`
         );
       } catch (error) {
-        logger.debug(
+        logger.info(
           `[APP-STATE] Failed to restore cached state for key: ${key} on mount`,
           error
         );
       } finally {
         localCache.remove(cacheKey);
-        logger.debug(
+        logger.info(
           `[APP-STATE] Removed cached state for key: ${key} on mount`
         );
       }
     } else {
-      logger.debug(
+      logger.info(
         `[APP-STATE] No cached state found for key: ${key} on mount`
       );
     }
@@ -136,28 +136,28 @@ export function useAppStateSaver<T>(key: string, data: T, setData: (value: T) =>
   }, [key, setData]);
 }
 
-logger.debug(`[APP-STATE] Setting up app state change listeners`);
+logger.info(`[APP-STATE] Setting up app state change listeners`);
 
 App.addListener('appStateChange', ({ isActive }) => {
-  logger.debug(
+  logger.info(
     `[APP-STATE] Capacitor app state change event - isActive: ${isActive}`
   );
   handleStateChange(isActive);
 });
 
 if (typeof document !== 'undefined') {
-  logger.debug(
+  logger.info(
     `[APP-STATE] Setting up document visibility change listener`
   );
   document.addEventListener('visibilitychange', () => {
     const isVisible = document.visibilityState === 'visible';
-    logger.debug(
+    logger.info(
       `[APP-STATE] Document visibility change event - isVisible: ${isVisible}`
     );
     handleStateChange(isVisible);
   });
 } else {
-  logger.debug(
+  logger.info(
     `[APP-STATE] Document not available - skipping visibility change listener`
   );
 }

--- a/utils/supabase/supabase-base.ts
+++ b/utils/supabase/supabase-base.ts
@@ -47,18 +47,27 @@ export class SupabaseBase {
   private cachedUser: AuthUser | null = null;
 
   setToken(token: string | null) {
-    if (token !== this.userToken) {
+    const prevToken = this.userToken;
+    const wasLoggedIn = prevToken !== null;
+    const isLoggedIn = token !== null;
+    const tokenChanged = token !== prevToken;
+
+    if (tokenChanged) {
       this.cachedUser = null;
     }
+
     this.userToken = token;
 
-    if (token) {
-      // 🔐 [DBG] Token set - Clear cache for fresh user session
-      logger.db("🔐 [DBG] Token set - Clearing cache for fresh user session");
-      localCache.clearPrefix();
-    } else {
-      // 🔐 [DBG] Token cleared - Clear cache on sign out
-      logger.db("🔐 [DBG] Token cleared - Clearing cache on sign out");
+    // Only clear cache when login state changes (sign in/out),
+    // not on token refreshes for the same user.
+    if (isLoggedIn !== wasLoggedIn) {
+      if (isLoggedIn) {
+        // 🔐 [DBG] Token set - Clear cache for fresh user session
+        logger.db("🔐 [DBG] Token set - Clearing cache for fresh user session");
+      } else {
+        // 🔐 [DBG] Token cleared - Clear cache on sign out
+        logger.db("🔐 [DBG] Token cleared - Clearing cache on sign out");
+      }
       localCache.clearPrefix();
     }
   }


### PR DESCRIPTION
## Summary
- avoid purging local cache when token merely refreshes
- clear cache only when login state toggles (sign in/out)

## Testing
- `npm test` *(fails: Real Authentication Integration Tests, Supabase API Routine CRUD Integration)*

------
https://chatgpt.com/codex/tasks/task_e_68c685219b0c8321b834133365c5d4c7