### PR TITLE
Redesign profile screen layout

### DIFF
--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -3,46 +3,130 @@ import { useState, useEffect } from "react";
 import { Card, CardContent } from "../ui/card";
 import { TactileButton } from "../TactileButton";
 import { Avatar, AvatarFallback } from "../ui/avatar";
-import { Badge } from "../ui/badge";
+import ListItem from "../ui/ListItem";
+import type { LucideIcon } from "lucide-react";
 import {
-  Trophy,
-  Target,
-  Zap,
-  Calendar,
-  Settings,
+  Bell,
+  BookOpen,
+  Info,
+  LifeBuoy,
   LogOut,
-  Dumbbell,
-  TrendingUp,
+  Rocket,
+  ShieldCheck,
+  SlidersHorizontal,
+  Smartphone,
+  User2,
 } from "lucide-react";
 import { useAuth } from "../AuthContext";
 import { supabaseAPI, Profile } from "../../utils/supabase/supabase-api";
 import { toast } from "sonner";
 import { AppScreen, Section, ScreenHeader, Stack } from "../layouts";
-import { logger, getLogLevel, setLogLevel, getAvailableLogLevels } from "../../utils/logging";
+import { logger } from "../../utils/logging";
 
-interface PersonalBest {
-  exercise: string;
-  weight: number;
-  reps: number;
-  date: string;
-}
+type AccentTone = "coral" | "peach" | "sage" | "mint" | "lavender";
+
+type SectionItem = {
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  accent: AccentTone;
+};
+
+type ProfileSection = {
+  title: string;
+  subtitle: string;
+  gradient: string;
+  items: SectionItem[];
+};
+
+const accentToneClasses: Record<AccentTone, string> = {
+  coral: "bg-warm-coral/25 text-black",
+  peach: "bg-warm-peach/30 text-black",
+  sage: "bg-warm-sage/30 text-black",
+  mint: "bg-warm-mint/30 text-black",
+  lavender: "bg-warm-lavender/30 text-black",
+};
+
+const PROFILE_SECTIONS: ProfileSection[] = [
+  {
+    title: "Account & Settings",
+    subtitle: "Manage your personal details, preferences, and privacy controls.",
+    gradient: "from-warm-cream/60 via-warm-peach/25 to-warm-mint/20",
+    items: [
+      {
+        label: "My Account",
+        description: "Edit your profile info and contact details.",
+        icon: User2,
+        accent: "coral",
+      },
+      {
+        label: "App Settings",
+        description: "Customize themes, tracking, and reminders.",
+        icon: SlidersHorizontal,
+        accent: "peach",
+      },
+      {
+        label: "Device Settings",
+        description: "Connect wearables and manage integrations.",
+        icon: Smartphone,
+        accent: "sage",
+      },
+      {
+        label: "Notifications",
+        description: "Choose what updates you want to receive.",
+        icon: Bell,
+        accent: "mint",
+      },
+      {
+        label: "Privacy Settings",
+        description: "Control data sharing and visibility preferences.",
+        icon: ShieldCheck,
+        accent: "lavender",
+      },
+    ],
+  },
+  {
+    title: "Support",
+    subtitle: "Get answers, tutorials, and inspiration for your journey.",
+    gradient: "from-warm-cream/55 via-warm-mint/20 to-warm-rose/15",
+    items: [
+      {
+        label: "Help & Support",
+        description: "Find FAQs or reach out to our team.",
+        icon: LifeBuoy,
+        accent: "mint",
+      },
+      {
+        label: "Tutorials",
+        description: "Learn tips to make the most of WorkItOut.",
+        icon: BookOpen,
+        accent: "peach",
+      },
+      {
+        label: "About",
+        description: "Discover what's new in the latest update.",
+        icon: Info,
+        accent: "sage",
+      },
+      {
+        label: "Getting Started",
+        description: "Set up your routines in a guided flow.",
+        icon: Rocket,
+        accent: "coral",
+      },
+    ],
+  },
+];
 
 interface ProfileScreenProps {
   bottomBar?: React.ReactNode;
 }
 
 export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
-
   const { userToken, signOut: authSignOut } = useAuth();
   const [profile, setProfile] = useState<Profile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
-
-  const personalBests: PersonalBest[] = [
-    { exercise: "Bench Press", weight: 225, reps: 5, date: "2 weeks ago" },
-    { exercise: "Squat", weight: 315, reps: 3, date: "1 week ago" },
-    { exercise: "Deadlift", weight: 405, reps: 1, date: "3 days ago" },
-  ];
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -101,12 +185,19 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
     return displayName.slice(0, 2).toUpperCase();
   };
 
+  const appVersion = import.meta.env.VITE_APP_VERSION ?? "1.0.0";
+  const buildNumber = import.meta.env.VITE_APP_BUILD ?? "1234";
+
   return (
     <AppScreen
-      header={<ScreenHeader title="Profile" 
-      showBorder={false}
-      denseSmall
-      titleClassName="text-[17px] font-bold"/>}
+      header={
+        <ScreenHeader
+          title="Profile"
+          showBorder={false}
+          denseSmall
+          titleClassName="text-[17px] font-bold"
+        />
+      }
       maxContent="responsive"
       showHeaderBorder={false}
       showBottomBarBorder={false}
@@ -116,167 +207,85 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
       headerInScrollArea={true}
     >
       <Stack gap="fluid">
-        {/* Profile Header */}
         <Section variant="plain" padding="none">
-          <Card className="bg-gradient-to-r from-warm-coral/10 to-warm-peach/10 border-warm-coral/20">
-            <CardContent className="p-6 text-center">
-              <Avatar className="w-20 h-20 mx-auto mb-4 bg-primary text-black">
-                <AvatarFallback className="bg-primary text-black text-lg">
-                  {getInitials()}
-                </AvatarFallback>
-              </Avatar>
+          <Card className="relative overflow-hidden border-0 bg-gradient-to-br from-warm-peach/35 via-warm-cream/50 to-warm-mint/30 shadow-md">
+            <CardContent className="p-6 text-center text-black">
+              <div className="absolute inset-x-0 -top-12 h-40 bg-gradient-to-b from-white/20 to-transparent pointer-events-none" />
+              <div className="relative">
+                <Avatar className="w-20 h-20 mx-auto mb-4 bg-primary text-black shadow-lg shadow-white/20">
+                  <AvatarFallback className="bg-primary text-black text-xl font-semibold">
+                    {getInitials()}
+                  </AvatarFallback>
+                </Avatar>
 
-              {isLoading ? (
-                <div className="text-black">Loading profile...</div>
-              ) : (
-                <>
-                  <h1 className="text-xl font-medium text-black mb-2">
-                    {getDisplayName()}
-                  </h1>
-                  {profile?.height_cm && profile?.weight_kg && (
-                    <div className="flex justify-center gap-4 text-sm text-black">
-                      <span>{profile.height_cm} cm</span>
-                      <span>•</span>
-                      <span>{profile.weight_kg} kg</span>
-                    </div>
-                  )}
-                </>
-              )}
-
-              <div className="flex justify-center gap-2 mt-4">
-                <Badge
-                  variant="secondary"
-                  className="bg-warm-sage/20 text-black border-warm-sage/30"
-                >
-                  <Zap size={12} className="mr-1" />
-                  Intermediate
-                </Badge>
-                <Badge
-                  variant="secondary"
-                  className="bg-warm-peach/20 text-black border-warm-peach/30"
-                >
-                  <Target size={12} className="mr-1" />
-                  5 Week Streak
-                </Badge>
+                {isLoading ? (
+                  <div className="text-black/80">Loading profile...</div>
+                ) : (
+                  <>
+                    <h1 className="text-2xl font-semibold text-black mb-1">
+                      {getDisplayName()}
+                    </h1>
+                    <p className="text-sm text-black/70">
+                      Tailor your experience and keep your journey personal.
+                    </p>
+                    {profile?.height_cm && profile?.weight_kg && (
+                      <div className="mt-4 inline-flex items-center gap-3 rounded-full bg-white/40 px-4 py-2 text-sm text-black/80">
+                        <span>{profile.height_cm} cm</span>
+                        <span className="text-black/40">•</span>
+                        <span>{profile.weight_kg} kg</span>
+                      </div>
+                    )}
+                  </>
+                )}
               </div>
             </CardContent>
           </Card>
         </Section>
 
-        {/* Stats Overview */}
-        <Section variant="plain" padding="none">
-          <div className="grid grid-cols-3 gap-3">
-            <Card className="bg-card/80 backdrop-blur-sm">
-              <CardContent className="p-4 text-center">
-                <div className="w-8 h-8 rounded-full bg-warm-coral/20 flex items-center justify-center mx-auto mb-2">
-                  <Dumbbell size={16} className="text-black" />
+        {PROFILE_SECTIONS.map((section) => (
+          <Section key={section.title} variant="plain" padding="none">
+            <div className="space-y-3">
+              <div className="px-1">
+                <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-black/60">
+                  {section.title}
+                </h2>
+                <p className="mt-1 text-sm text-black/60">
+                  {section.subtitle}
+                </p>
+              </div>
+
+              <div
+                className={`rounded-3xl border border-border/40 bg-gradient-to-br ${section.gradient} shadow-sm overflow-hidden backdrop-blur-sm`}
+              >
+                <div className="divide-y divide-border/40">
+                  {section.items.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <ListItem
+                        key={item.label}
+                        as="button"
+                        leading={<Icon size={18} />}
+                        leadingClassName={`w-12 h-12 rounded-2xl flex items-center justify-center ${accentToneClasses[item.accent]}`}
+                        primary={item.label}
+                        primaryClassName="text-base font-semibold text-black"
+                        secondary={item.description}
+                        secondaryClassName="text-sm text-black/70"
+                        rightIcon="chevron"
+                        className="px-4 transition-all duration-200 hover:bg-white/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                      />
+                    );
+                  })}
                 </div>
-                <div className="text-lg font-medium text-black">124</div>
-                <div className="text-xs text-black">Workouts</div>
-              </CardContent>
-            </Card>
+              </div>
+            </div>
+          </Section>
+        ))}
 
-            <Card className="bg-card/80 backdrop-blur-sm">
-              <CardContent className="p-4 text-center">
-                <div className="w-8 h-8 rounded-full bg-warm-sage/20 flex items-center justify-center mx-auto mb-2">
-                  <Calendar size={16} className="text-black" />
-                </div>
-                <div className="text-lg font-medium text-black">186</div>
-                <div className="text-xs text-black">Days Active</div>
-              </CardContent>
-            </Card>
-
-            <Card className="bg-card/80 backdrop-blur-sm">
-              <CardContent className="p-4 text-center">
-                <div className="w-8 h-8 rounded-full bg-warm-peach/20 flex items-center justify-center mx-auto mb-2">
-                  <TrendingUp size={16} className="text-black" />
-                </div>
-                <div className="text-lg font-medium text-black">+12%</div>
-                <div className="text-xs text-black">Strength</div>
-              </CardContent>
-            </Card>
-          </div>
-        </Section>
-
-        {/* Personal Bests */}
         <Section variant="plain" padding="none">
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
-              <Trophy size={20} className="text-black" />
-              <h2 className="text-lg text-black">Personal Bests</h2>
-            </div>
-
-            <div className="space-y-2">
-              {personalBests.map((pb, index) => (
-                <Card key={index} className="bg-card/80 backdrop-blur-sm">
-                  <CardContent className="p-4">
-                    <div className="flex justify-between items-center">
-                      <div>
-                        <h3 className="font-medium text-black">
-                          {pb.exercise}
-                        </h3>
-                        <p className="text-sm text-black">{pb.date}</p>
-                      </div>
-                      <div className="text-right">
-                        <div className="font-medium text-black">
-                          {pb.weight} lbs
-                        </div>
-                        <div className="text-sm text-black">
-                          {pb.reps} reps
-                        </div>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        </Section>
-
-        {/* Logging Control */}
-        <Section variant="plain" padding="none">
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
-              <Settings size={20} className="text-black" />
-              <h2 className="text-lg text-black">Logging Level</h2>
-            </div>
-            
-            <div className="grid grid-cols-2 gap-2">
-              {getAvailableLogLevels().map((level) => (
-                <TactileButton
-                  key={level}
-                  variant={getLogLevel() === level ? "primary" : "secondary"}
-                  className="text-sm rounded-xl border-0 font-medium"
-                  onClick={() => {
-                    setLogLevel(level);
-                    toast.success(`Log level set to: ${level}`);
-                  }}
-                >
-                  {level.toUpperCase()}
-                </TactileButton>
-              ))}
-            </div>
-            
-            <div className="text-xs text-black text-center">
-              Current: {getLogLevel().toUpperCase()}
-            </div>
-          </div>
-        </Section>
-
-        {/* Action Buttons */}
-        <Section variant="plain" padding="none">
-          <div className="space-y-3">
-            <TactileButton
-              variant="secondary"
-              className="w-full flex items-center justify-center gap-2 rounded-xl border-0 font-medium"
-            >
-              <Settings size={16} />
-              Settings
-            </TactileButton>
-
+          <div className="rounded-3xl border border-border/40 bg-card/70 px-6 py-6 text-center shadow-sm backdrop-blur-sm">
             <TactileButton
               variant="sage"
-              className="w-full flex items-center justify-center gap-2 rounded-xl border-0 font-medium"
+              className="w-full flex items-center justify-center gap-2 rounded-2xl border-0 font-semibold"
               onClick={handleSignOut}
               disabled={isSigningOut}
             >
@@ -285,23 +294,15 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
               ) : (
                 <LogOut size={16} />
               )}
-              {isSigningOut ? "Signing Out..." : "Sign Out"}
+              {isSigningOut ? "Signing Out..." : "Log Out"}
             </TactileButton>
           </div>
         </Section>
 
-        {/* App Info */}
         <Section variant="plain" padding="none">
-          <Card className="bg-gradient-to-r from-warm-sage/10 to-warm-mint/10 border-warm-sage/20">
-            <CardContent className="p-4 text-center">
-              <div className="text-sm text-black">
-                Workout Tracker v1.0
-              </div>
-              <div className="text-xs text-black mt-1">
-                Powered by Supabase
-              </div>
-            </CardContent>
-          </Card>
+          <div className="text-center text-xs uppercase tracking-[0.25em] text-black/50">
+            App Version: {appVersion} (Build {buildNumber})
+          </div>
         </Section>
       </Stack>
     </AppScreen>


### PR DESCRIPTION
## Summary
- restyle the profile screen header with a gradient hero card and dynamic profile details
- replace the stats/logging cards with warm-palette section cards that list account, settings, and support actions
- streamline the footer with a prominent logout button and version stamp for an app-like preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf34ef4148321acdc5defed9fdf24