### PR TITLE
Align Profile screen typography and colors

### DIFF
--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import { AppScreen, Section, ScreenHeader, Stack } from "../layouts";
 import { logger } from "../../utils/logging";
 import type { LucideIcon } from "lucide-react";
+import ListItem from "../ui/ListItem";
 
 interface ProfileScreenProps {
   bottomBar?: React.ReactNode;
@@ -50,31 +51,31 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           label: "My Account",
           description: "Profile details and connected services",
           icon: User,
-          iconClassName: "bg-warm-peach/20 border border-warm-peach/30 text-black",
+          iconClassName: "bg-warm-peach/20 border border-warm-peach/40",
         },
         {
           label: "App Settings",
           description: "Customize notifications and themes",
           icon: Settings,
-          iconClassName: "bg-warm-sage/20 border border-warm-sage/30 text-black",
+          iconClassName: "bg-warm-sage/20 border border-warm-sage/40",
         },
         {
           label: "Device Settings",
           description: "Manage Health Connect and devices",
           icon: Smartphone,
-          iconClassName: "bg-warm-mint/20 border border-warm-mint/30 text-black",
+          iconClassName: "bg-warm-mint/20 border border-warm-mint/40",
         },
         {
           label: "Notifications",
           description: "Choose reminders that keep you on track",
           icon: Bell,
-          iconClassName: "bg-warm-coral/20 border border-warm-coral/30 text-black",
+          iconClassName: "bg-warm-coral/20 border border-warm-coral/40",
         },
         {
           label: "Privacy Settings",
           description: "Control data sharing and visibility",
           icon: Shield,
-          iconClassName: "bg-warm-cream/40 border border-warm-cream/60 text-black",
+          iconClassName: "bg-warm-cream/40 border border-warm-cream/60",
         },
       ],
     },
@@ -85,25 +86,25 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           label: "Help & Support",
           description: "Get help or ask a question",
           icon: LifeBuoy,
-          iconClassName: "bg-warm-sage/20 border border-warm-sage/30 text-black",
+          iconClassName: "bg-warm-sage/20 border border-warm-sage/40",
         },
         {
           label: "Tutorials",
           description: "Quick tips to learn the app",
           icon: BookOpen,
-          iconClassName: "bg-warm-mint/20 border border-warm-mint/30 text-black",
+          iconClassName: "bg-warm-mint/20 border border-warm-mint/40",
         },
         {
           label: "About",
           description: "Our mission and release notes",
           icon: Info,
-          iconClassName: "bg-warm-peach/20 border border-warm-peach/30 text-black",
+          iconClassName: "bg-warm-peach/20 border border-warm-peach/40",
         },
         {
           label: "Getting Started",
           description: "Guided setup for new members",
           icon: PlayCircle,
-          iconClassName: "bg-warm-cream/40 border border-warm-cream/60 text-black",
+          iconClassName: "bg-warm-cream/40 border border-warm-cream/60",
         },
       ],
     },
@@ -169,12 +170,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
   return (
     <AppScreen
       header={
-        <ScreenHeader
-          title="Profile"
-          showBorder={false}
-          denseSmall
-          titleClassName="text-[17px] font-bold"
-        />
+        <ScreenHeader title="Profile" showBorder={false} denseSmall />
       }
       maxContent="responsive"
       showHeaderBorder={false}
@@ -185,19 +181,19 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
     >
       <Stack gap="fluid">
         <Section variant="plain" padding="none">
-          <Card className="border-white/20 bg-gradient-to-b from-warm-peach/15 via-warm-cream/30 to-warm-sage/20">
-            <CardContent className="p-6 text-center">
-              <Avatar className="w-20 h-20 mx-auto mb-4 bg-primary text-black shadow-lg shadow-primary/30">
+          <Card className="border border-border bg-card shadow-md">
+            <CardContent className="p-6 text-center space-y-3">
+              <Avatar className="w-20 h-20 mx-auto bg-primary text-black shadow-lg shadow-primary/30">
                 <AvatarFallback className="bg-primary text-black text-lg">
                   {getInitials()}
                 </AvatarFallback>
               </Avatar>
 
               {isLoading ? (
-                <div className="text-black/70">Loading profile...</div>
+                <div className="text-sm text-black/60">Loading profile...</div>
               ) : (
                 <>
-                  <h1 className="text-xl font-semibold text-black mb-1">
+                  <h1 className="text-2xl font-semibold text-black">
                     {getDisplayName()}
                   </h1>
                   <p className="text-sm text-black/70">
@@ -211,31 +207,29 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
 
         {navigationSections.map((section) => (
           <Section key={section.title} variant="plain" padding="none">
-            <div className="rounded-3xl border border-white/20 bg-gradient-to-b from-white/40 via-transparent to-warm-cream/20 backdrop-blur-sm p-5">
-              <p className="text-[11px] uppercase tracking-[0.3em] text-black/50 mb-4">
+            <div className="rounded-2xl border border-border bg-card/80 backdrop-blur-sm p-4 sm:p-5 space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-black/60">
                 {section.title}
               </p>
-              <div className="space-y-3">
+              <div className="space-y-2">
                 {section.items.map((item) => {
                   const Icon = item.icon;
                   return (
                     <Card
                       key={item.label}
-                      className="border-white/30 bg-card/80 transition-transform duration-200 hover:-translate-y-0.5"
+                      className="border border-border bg-card shadow-sm transition-transform duration-200 hover:-translate-y-0.5"
                     >
-                      <CardContent className="px-4 py-3">
-                        <div className="flex items-center gap-3">
-                          <div className={`flex h-11 w-11 items-center justify-center rounded-full ${item.iconClassName}`}>
-                            <Icon size={18} className="text-black" />
-                          </div>
-                          <div className="flex-1">
-                            <p className="text-sm font-medium text-black">{item.label}</p>
-                            {item.description ? (
-                              <p className="text-xs text-black/60">{item.description}</p>
-                            ) : null}
-                          </div>
-                          <ChevronRight size={18} className="text-black/40" />
-                        </div>
+                      <CardContent className="p-0">
+                        <ListItem
+                          className="px-4"
+                          leading={<Icon size={18} className="text-black" />}
+                          leadingClassName={`flex h-11 w-11 items-center justify-center rounded-xl text-black ${item.iconClassName}`}
+                          primary={item.label}
+                          primaryClassName="text-sm font-medium text-black"
+                          secondary={item.description}
+                          secondaryClassName="text-xs text-black/60"
+                          trailing={<ChevronRight size={18} className="text-black/30" />}
+                        />
                       </CardContent>
                     </Card>
                   );
@@ -249,7 +243,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           <div className="space-y-4">
             <TactileButton
               variant="secondary"
-              className="w-full flex items-center justify-center gap-2 rounded-2xl border-0 font-medium"
+              className="w-full flex items-center justify-center gap-2 rounded-2xl border-0 font-medium text-black"
               onClick={handleSignOut}
               disabled={isSigningOut}
             >


### PR DESCRIPTION
## Summary
- refresh the profile header card with the standard card styling and typography used elsewhere
- render navigation links through the shared ListItem component to align text sizes, weights, and neutral colors
- adjust action button and icon badge styling so the palette and fonts match the broader app

## Testing
- npm test -- --watchAll=false *(fails: existing Jest setup cannot parse import.meta in supabase-db-write.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cafee32968832194a90a7a1ed8141e