### PR TITLE
Add editable My Account screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -49,6 +49,8 @@ function AppContent() {
     handleExerciseSetupComplete,
     onRoutineSelection,
     closeExerciseSetupToRoutines,
+    showProfileAccount,
+    closeProfileAccount,
   } = useAppNavigation();
 
   // ⬅️ now includes authReady
@@ -107,6 +109,8 @@ function AppContent() {
           onCloseExerciseSetupToRoutines={closeExerciseSetupToRoutines}
           bottomBar={bottomBarEl}
           onOverlayChange={setOverlayOpen}
+          onNavigateToMyAccount={showProfileAccount}
+          onCloseMyAccount={closeProfileAccount}
         />
       </main>
     </div>

--- a/App.tsx
+++ b/App.tsx
@@ -51,6 +51,8 @@ function AppContent() {
     closeExerciseSetupToRoutines,
     showProfileAccount,
     closeProfileAccount,
+    showProfileAppSettings,
+    closeProfileAppSettings,
   } = useAppNavigation();
 
   // ⬅️ now includes authReady
@@ -111,6 +113,8 @@ function AppContent() {
           onOverlayChange={setOverlayOpen}
           onNavigateToMyAccount={showProfileAccount}
           onCloseMyAccount={closeProfileAccount}
+          onNavigateToAppSettings={showProfileAppSettings}
+          onCloseAppSettings={closeProfileAppSettings}
         />
       </main>
     </div>

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -7,6 +7,7 @@ import EditMeasurementsScreen from "./screens/EditMeasurementsScreen";
 import { ProgressScreen } from "./screens/ProgressScreen";
 import { ProfileScreen } from "./screens/ProfileScreen";
 import { MyAccountScreen } from "./screens/profile/MyAccountScreen";
+import { AppSettingsScreen } from "./screens/profile/AppSettingsScreen";
 import { SignInScreen } from "./screens/SignInScreen";
 import { SignUpScreen } from "./screens/SignUpScreen";
 import { WelcomeScreen } from "./screens/WelcomeScreen";
@@ -59,6 +60,8 @@ interface AppRouterProps {
 
   onNavigateToMyAccount: () => void;
   onCloseMyAccount: () => void;
+  onNavigateToAppSettings: () => void;
+  onCloseAppSettings: () => void;
 }
 
 export function AppRouter({
@@ -99,6 +102,8 @@ export function AppRouter({
   onOverlayChange,
   onNavigateToMyAccount,
   onCloseMyAccount,
+  onNavigateToAppSettings,
+  onCloseAppSettings,
 }: AppRouterProps) {
   logger.debug(`🔍 [DBG] CURRENT SCREEN: ${currentView.toUpperCase()}`);
 
@@ -216,6 +221,7 @@ export function AppRouter({
         <ProfileScreen
           bottomBar={bottomBar}
           onNavigateToMyAccount={onNavigateToMyAccount}
+          onNavigateToAppSettings={onNavigateToAppSettings}
         />
       )}
 
@@ -225,6 +231,14 @@ export function AppRouter({
         exitTo="right"
       >
         <MyAccountScreen onBack={onCloseMyAccount} />
+      </SlideTransition>
+
+      <SlideTransition
+        show={currentView === "profile-app-settings"}
+        enterFrom="right"
+        exitTo="right"
+      >
+        <AppSettingsScreen onBack={onCloseAppSettings} />
       </SlideTransition>
     </div>
   );

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -6,6 +6,7 @@ import EditMeasurementsScreen from "./screens/EditMeasurementsScreen";
 
 import { ProgressScreen } from "./screens/ProgressScreen";
 import { ProfileScreen } from "./screens/ProfileScreen";
+import { MyAccountScreen } from "./screens/profile/MyAccountScreen";
 import { SignInScreen } from "./screens/SignInScreen";
 import { SignUpScreen } from "./screens/SignUpScreen";
 import { WelcomeScreen } from "./screens/WelcomeScreen";
@@ -55,6 +56,9 @@ interface AppRouterProps {
   bottomBar?: React.ReactNode;
   /** notify App when a modal/sheet is open so it can hide BottomNavigation */
   onOverlayChange?: (open: boolean) => void;
+
+  onNavigateToMyAccount: () => void;
+  onCloseMyAccount: () => void;
 }
 
 export function AppRouter({
@@ -93,6 +97,8 @@ export function AppRouter({
   onCloseExerciseSetupToRoutines,
   bottomBar,
   onOverlayChange,
+  onNavigateToMyAccount,
+  onCloseMyAccount,
 }: AppRouterProps) {
   logger.debug(`🔍 [DBG] CURRENT SCREEN: ${currentView.toUpperCase()}`);
 
@@ -206,7 +212,20 @@ export function AppRouter({
       </SlideTransition>
 
       {currentView === "progress" && <ProgressScreen bottomBar={bottomBar} />}
-      {currentView === "profile" && <ProfileScreen bottomBar={bottomBar} />}
+      {currentView === "profile" && (
+        <ProfileScreen
+          bottomBar={bottomBar}
+          onNavigateToMyAccount={onNavigateToMyAccount}
+        />
+      )}
+
+      <SlideTransition
+        show={currentView === "profile-my-account"}
+        enterFrom="right"
+        exitTo="right"
+      >
+        <MyAccountScreen onBack={onCloseMyAccount} />
+      </SlideTransition>
     </div>
   );
 }

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -26,9 +26,10 @@ import type { LucideIcon } from "lucide-react";
 interface ProfileScreenProps {
   bottomBar?: React.ReactNode;
   onNavigateToMyAccount?: () => void;
+  onNavigateToAppSettings?: () => void;
 }
 
-export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScreenProps) {
+export function ProfileScreen({ bottomBar, onNavigateToMyAccount, onNavigateToAppSettings }: ProfileScreenProps) {
 
   const { userToken, signOut: authSignOut } = useAuth();
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -57,6 +58,7 @@ export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScree
           label: "App Settings",
           description: "Customize notifications and themes",
           icon: Settings,
+          onPress: onNavigateToAppSettings,
         },
         {
           label: "Device Settings",

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -25,9 +25,10 @@ import type { LucideIcon } from "lucide-react";
 
 interface ProfileScreenProps {
   bottomBar?: React.ReactNode;
+  onNavigateToMyAccount?: () => void;
 }
 
-export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
+export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScreenProps) {
 
   const { userToken, signOut: authSignOut } = useAuth();
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -40,7 +41,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
       label: string;
       description?: string;
       icon: LucideIcon;
-      iconClassName: string;
+      onPress?: () => void;
     }>;
   }> = [
     {
@@ -50,31 +51,27 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           label: "My Account",
           description: "Profile details and connected services",
           icon: User,
-          iconClassName: "bg-warm-peach/20 border border-warm-peach/30 text-black",
+          onPress: onNavigateToMyAccount,
         },
         {
           label: "App Settings",
           description: "Customize notifications and themes",
           icon: Settings,
-          iconClassName: "bg-warm-sage/20 border border-warm-sage/30 text-black",
         },
         {
           label: "Device Settings",
           description: "Manage Health Connect and devices",
           icon: Smartphone,
-          iconClassName: "bg-warm-mint/20 border border-warm-mint/30 text-black",
         },
         {
           label: "Notifications",
           description: "Choose reminders that keep you on track",
           icon: Bell,
-          iconClassName: "bg-warm-coral/20 border border-warm-coral/30 text-black",
         },
         {
           label: "Privacy Settings",
           description: "Control data sharing and visibility",
           icon: Shield,
-          iconClassName: "bg-warm-cream/40 border border-warm-cream/60 text-black",
         },
       ],
     },
@@ -85,25 +82,21 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           label: "Help & Support",
           description: "Get help or ask a question",
           icon: LifeBuoy,
-          iconClassName: "bg-warm-sage/20 border border-warm-sage/30 text-black",
         },
         {
           label: "Tutorials",
           description: "Quick tips to learn the app",
           icon: BookOpen,
-          iconClassName: "bg-warm-mint/20 border border-warm-mint/30 text-black",
         },
         {
           label: "About",
           description: "Our mission and release notes",
           icon: Info,
-          iconClassName: "bg-warm-peach/20 border border-warm-peach/30 text-black",
         },
         {
           label: "Getting Started",
           description: "Guided setup for new members",
           icon: PlayCircle,
-          iconClassName: "bg-warm-cream/40 border border-warm-cream/60 text-black",
         },
       ],
     },
@@ -173,7 +166,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           title="Profile"
           showBorder={false}
           denseSmall
-          titleClassName="text-[17px] font-bold"
+          titleClassName="text-[17px] font-bold text-black"
         />
       }
       maxContent="responsive"
@@ -185,22 +178,22 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
     >
       <Stack gap="fluid">
         <Section variant="plain" padding="none">
-          <Card className="border-white/20 bg-gradient-to-b from-warm-peach/15 via-warm-cream/30 to-warm-sage/20">
+          <Card className="border border-border bg-card/80 backdrop-blur-sm shadow-sm">
             <CardContent className="p-6 text-center">
               <Avatar className="w-20 h-20 mx-auto mb-4 bg-primary text-black shadow-lg shadow-primary/30">
-                <AvatarFallback className="bg-primary text-black text-lg">
+                <AvatarFallback className="bg-primary text-black text-lg font-semibold">
                   {getInitials()}
                 </AvatarFallback>
               </Avatar>
 
               {isLoading ? (
-                <div className="text-black/70">Loading profile...</div>
+                <div className="text-sm text-black/60">Loading profile...</div>
               ) : (
                 <>
-                  <h1 className="text-xl font-semibold text-black mb-1">
+                  <h1 className="text-[clamp(20px,5vw,26px)] font-semibold text-black mb-1">
                     {getDisplayName()}
                   </h1>
-                  <p className="text-sm text-black/70">
+                  <p className="text-sm text-black/60">
                     Keep your profile up to date to personalize your plan.
                   </p>
                 </>
@@ -211,33 +204,37 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
 
         {navigationSections.map((section) => (
           <Section key={section.title} variant="plain" padding="none">
-            <div className="rounded-3xl border border-white/20 bg-gradient-to-b from-white/40 via-transparent to-warm-cream/20 backdrop-blur-sm p-5">
-              <p className="text-[11px] uppercase tracking-[0.3em] text-black/50 mb-4">
+            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-5 shadow-sm">
+              <p className="text-md font-bold uppercase tracking-[0.12em] text-black mb-4">
                 {section.title}
               </p>
               <div className="space-y-3">
                 {section.items.map((item) => {
                   const Icon = item.icon;
                   return (
-                    <Card
-                      key={item.label}
-                      className="border-white/30 bg-card/80 transition-transform duration-200 hover:-translate-y-0.5"
-                    >
-                      <CardContent className="px-4 py-3">
-                        <div className="flex items-center gap-3">
-                          <div className={`flex h-11 w-11 items-center justify-center rounded-full ${item.iconClassName}`}>
-                            <Icon size={18} className="text-black" />
+                    <CardContent key={item.label} className="px-0 pt-1 pb-1">
+                      <button
+                        type="button"
+                        onClick={item.onPress}
+                        disabled={!item.onPress}
+                        className="w-full rounded-2xl px-4 py-3 text-left transition hover:bg-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40 disabled:cursor-default disabled:opacity-60"
+                      >
+                        <div className="flex items-start gap-3">
+                          <Icon size={18} className="mt-1 text-black" />
+                          <div className="flex-1 leading-none">
+                            <p className="text-sm uppercase font-medium text-black leading-tight">
+                              {item.label}
+                            </p>
+                            {item.description && (
+                              <p className="text-xs text-black/60 leading-tight m-0">
+                                {item.description}
+                              </p>
+                            )}
                           </div>
-                          <div className="flex-1">
-                            <p className="text-sm font-medium text-black">{item.label}</p>
-                            {item.description ? (
-                              <p className="text-xs text-black/60">{item.description}</p>
-                            ) : null}
-                          </div>
-                          <ChevronRight size={18} className="text-black/40" />
+                          <ChevronRight size={18} className="text-black/30 self-center" />
                         </div>
-                      </CardContent>
-                    </Card>
+                      </button>
+                    </CardContent>
                   );
                 })}
               </div>
@@ -249,7 +246,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
           <div className="space-y-4">
             <TactileButton
               variant="secondary"
-              className="w-full flex items-center justify-center gap-2 rounded-2xl border-0 font-medium"
+              className="w-full flex items-center justify-center gap-2 rounded-2xl border-0 font-medium text-black"
               onClick={handleSignOut}
               disabled={isSigningOut}
             >
@@ -261,7 +258,7 @@ export function ProfileScreen({ bottomBar }: ProfileScreenProps) {
               {isSigningOut ? "Signing Out..." : "Logout"}
             </TactileButton>
 
-            <div className="text-center text-xs text-black/60">
+            <div className="text-center text-xs text-black/50">
               App Version: 1.0.0 (Build 1234)
             </div>
           </div>

--- a/components/screens/profile/AppSettingsScreen.tsx
+++ b/components/screens/profile/AppSettingsScreen.tsx
@@ -78,6 +78,8 @@ export function AppSettingsScreen({ onBack }: AppSettingsScreenProps) {
                     { value: "m", label: "M" },
                   ]}
                   size="md"
+                  variant="filled"
+                  tone="accent"
                 />
               </div>
             </div>
@@ -100,34 +102,14 @@ export function AppSettingsScreen({ onBack }: AppSettingsScreenProps) {
                     { value: "lbs", label: "LBS" },
                   ]}
                   size="md"
+                  variant="filled"
+                  tone="accent"
                 />
               </div>
             </div>
           </div>
         </Section>
 
-        <Section variant="plain" padding="none">
-          <Card className="border border-border bg-card/80 backdrop-blur-sm shadow-sm">
-            <CardContent className="p-5 space-y-3">
-              <p className="text-xs uppercase tracking-[0.14em] text-black/60">
-                Current Settings
-              </p>
-              <div className="space-y-2">
-                <div className="flex items-center justify-between text-sm text-black">
-                  <span className="text-black/70">Length</span>
-                  <span className="font-semibold">{lengthUnit.toUpperCase()}</span>
-                </div>
-                <div className="flex items-center justify-between text-sm text-black">
-                  <span className="text-black/70">Weight</span>
-                  <span className="font-semibold">{weightUnit.toUpperCase()}</span>
-                </div>
-              </div>
-              <p className="text-xs text-black/50">
-                These preferences are applied throughout the app, including your profile and workout tracking.
-              </p>
-            </CardContent>
-          </Card>
-        </Section>
       </Stack>
     </AppScreen>
   );

--- a/components/screens/profile/AppSettingsScreen.tsx
+++ b/components/screens/profile/AppSettingsScreen.tsx
@@ -40,6 +40,7 @@ export function AppSettingsScreen({ onBack }: AppSettingsScreenProps) {
       maxContent="responsive"
       showHeaderBorder={false}
       showBottomBarBorder={false}
+      headerInScrollArea={false}
     >
       <Stack gap="fluid">
         <Section variant="plain" padding="none">
@@ -62,50 +63,40 @@ export function AppSettingsScreen({ onBack }: AppSettingsScreenProps) {
 
         <Section variant="plain" padding="none">
           <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm space-y-6">
-            <div className="space-y-2">
-              <p className="text-xs uppercase tracking-[0.14em] text-black/60">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-black">
                 Length Units
               </p>
-              <div className="flex items-center justify-between gap-4">
-                <div className="text-sm text-black/80">
-                  Choose how height is displayed
-                </div>
-                <SegmentedToggle<LengthUnit>
-                  value={lengthUnit}
-                  onChange={handleLengthUnitChange}
-                  options={[
-                    { value: "cm", label: "CM" },
-                    { value: "m", label: "M" },
-                  ]}
-                  size="md"
-                  variant="filled"
-                  tone="accent"
-                />
-              </div>
+              <SegmentedToggle<LengthUnit>
+                value={lengthUnit}
+                onChange={handleLengthUnitChange}
+                options={[
+                  { value: "cm", label: "CM" },
+                  { value: "m", label: "M" },
+                ]}
+                size="md"
+                variant="filled"
+                tone="accent"
+              />
             </div>
 
             <div className="h-px bg-border/80" />
 
-            <div className="space-y-2">
-              <p className="text-xs uppercase tracking-[0.14em] text-black/60">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-black">
                 Weight Units
               </p>
-              <div className="flex items-center justify-between gap-4">
-                <div className="text-sm text-black/80">
-                  Choose how weight is displayed
-                </div>
-                <SegmentedToggle<WeightUnit>
-                  value={weightUnit}
-                  onChange={handleWeightUnitChange}
-                  options={[
-                    { value: "kg", label: "KG" },
-                    { value: "lbs", label: "LBS" },
-                  ]}
-                  size="md"
-                  variant="filled"
-                  tone="accent"
-                />
-              </div>
+              <SegmentedToggle<WeightUnit>
+                value={weightUnit}
+                onChange={handleWeightUnitChange}
+                options={[
+                  { value: "kg", label: "KG" },
+                  { value: "lbs", label: "LBS" },
+                ]}
+                size="md"
+                variant="filled"
+                tone="accent"
+              />
             </div>
           </div>
         </Section>

--- a/components/screens/profile/AppSettingsScreen.tsx
+++ b/components/screens/profile/AppSettingsScreen.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import { Settings2 } from "lucide-react";
+import { AppScreen, ScreenHeader, Section, Stack } from "../../layouts";
+import { Card, CardContent } from "../../ui/card";
+import SegmentedToggle from "../../segmented/SegmentedToggle";
+import { logger } from "../../../utils/logging";
+
+interface AppSettingsScreenProps {
+  onBack: () => void;
+}
+
+type LengthUnit = "cm" | "m";
+type WeightUnit = "kg" | "lbs";
+
+export function AppSettingsScreen({ onBack }: AppSettingsScreenProps) {
+  const [lengthUnit, setLengthUnit] = useState<LengthUnit>("cm");
+  const [weightUnit, setWeightUnit] = useState<WeightUnit>("kg");
+
+  const handleLengthUnitChange = (value: LengthUnit) => {
+    setLengthUnit(value);
+    logger.info(`[AppSettings] Length unit set to ${value.toUpperCase()}`);
+  };
+
+  const handleWeightUnitChange = (value: WeightUnit) => {
+    setWeightUnit(value);
+    logger.info(`[AppSettings] Weight unit set to ${value.toUpperCase()}`);
+  };
+
+  return (
+    <AppScreen
+      header={
+        <ScreenHeader
+          title="App Settings"
+          onBack={onBack}
+          showBorder={false}
+          denseSmall
+          titleClassName="text-[17px] font-bold text-black"
+        />
+      }
+      maxContent="responsive"
+      showHeaderBorder={false}
+      showBottomBarBorder={false}
+    >
+      <Stack gap="fluid">
+        <Section variant="plain" padding="none">
+          <Card className="border border-border bg-card/80 backdrop-blur-sm shadow-sm">
+            <CardContent className="p-6 text-center space-y-4">
+              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/80 text-black shadow-md shadow-primary/30">
+                <Settings2 size={22} />
+              </div>
+              <div className="space-y-1">
+                <h1 className="text-[clamp(20px,5vw,26px)] font-semibold text-black">
+                  Unit Preferences
+                </h1>
+                <p className="text-sm text-black/60">
+                  Choose how measurements are displayed throughout the app.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </Section>
+
+        <Section variant="plain" padding="none">
+          <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm space-y-6">
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.14em] text-black/60">
+                Length Units
+              </p>
+              <div className="flex items-center justify-between gap-4">
+                <div className="text-sm text-black/80">
+                  Choose how height is displayed
+                </div>
+                <SegmentedToggle<LengthUnit>
+                  value={lengthUnit}
+                  onChange={handleLengthUnitChange}
+                  options={[
+                    { value: "cm", label: "CM" },
+                    { value: "m", label: "M" },
+                  ]}
+                  size="md"
+                />
+              </div>
+            </div>
+
+            <div className="h-px bg-border/80" />
+
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.14em] text-black/60">
+                Weight Units
+              </p>
+              <div className="flex items-center justify-between gap-4">
+                <div className="text-sm text-black/80">
+                  Choose how weight is displayed
+                </div>
+                <SegmentedToggle<WeightUnit>
+                  value={weightUnit}
+                  onChange={handleWeightUnitChange}
+                  options={[
+                    { value: "kg", label: "KG" },
+                    { value: "lbs", label: "LBS" },
+                  ]}
+                  size="md"
+                />
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <Section variant="plain" padding="none">
+          <Card className="border border-border bg-card/80 backdrop-blur-sm shadow-sm">
+            <CardContent className="p-5 space-y-3">
+              <p className="text-xs uppercase tracking-[0.14em] text-black/60">
+                Current Settings
+              </p>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-sm text-black">
+                  <span className="text-black/70">Length</span>
+                  <span className="font-semibold">{lengthUnit.toUpperCase()}</span>
+                </div>
+                <div className="flex items-center justify-between text-sm text-black">
+                  <span className="text-black/70">Weight</span>
+                  <span className="font-semibold">{weightUnit.toUpperCase()}</span>
+                </div>
+              </div>
+              <p className="text-xs text-black/50">
+                These preferences are applied throughout the app, including your profile and workout tracking.
+              </p>
+            </CardContent>
+          </Card>
+        </Section>
+      </Stack>
+    </AppScreen>
+  );
+}

--- a/components/screens/profile/MyAccountScreen.tsx
+++ b/components/screens/profile/MyAccountScreen.tsx
@@ -6,11 +6,12 @@ import {
   type FormEvent,
   type InputHTMLAttributes,
 } from "react";
-import { AppScreen, ScreenHeader, Section, Spacer, Stack } from "../../layouts";
+import { AppScreen, ScreenHeader, Section, Stack } from "../../layouts";
+import { BottomNavigation } from "../../BottomNavigation";
+import { BottomNavigationButton } from "../../BottomNavigationButton";
 import { Avatar, AvatarFallback } from "../../ui/avatar";
 import { Input } from "../../ui/input";
 import { Label } from "../../ui/label";
-import { TactileButton } from "../../TactileButton";
 import { supabaseAPI, Profile } from "../../../utils/supabase/supabase-api";
 import { toast } from "sonner";
 import { logger } from "../../../utils/logging";
@@ -36,6 +37,7 @@ const emptyState: FormState = {
 };
 
 export function MyAccountScreen({ onBack }: MyAccountScreenProps) {
+  const formId = "my-account-form";
   const [formState, setFormState] = useState<FormState>(emptyState);
   const [initialState, setInitialState] = useState<FormState>(emptyState);
   const [isLoading, setIsLoading] = useState(false);
@@ -163,9 +165,29 @@ export function MyAccountScreen({ onBack }: MyAccountScreenProps) {
       maxContent="responsive"
       showHeaderBorder={false}
       showBottomBarBorder={false}
+      bottomBar={
+        <BottomNavigation>
+          <BottomNavigationButton
+            type="submit"
+            form={formId}
+            disabled={!isDirty || isSaving || isLoading}
+            className="min-w-[160px]"
+          >
+            {isSaving ? (
+              <div className="flex items-center justify-center gap-2">
+                <div className="w-4 h-4 animate-spin border-2 border-current border-t-transparent rounded-full" />
+                Saving...
+              </div>
+            ) : (
+              "Save Changes"
+            )}
+          </BottomNavigationButton>
+        </BottomNavigation>
+      }
+      bottomBarSticky
       headerInScrollArea
     >
-      <form onSubmit={handleSubmit} className="h-full">
+      <form id={formId} onSubmit={handleSubmit} className="h-full">
         <Stack gap="fluid">
           <Section variant="plain" padding="none">
             <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm px-6 py-8 text-center shadow-sm">
@@ -279,24 +301,7 @@ export function MyAccountScreen({ onBack }: MyAccountScreenProps) {
           </Section>
 
           <Section variant="plain" padding="none">
-            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm text-center space-y-4">
-              <TactileButton
-                type="submit"
-                className="w-full flex items-center justify-center gap-2 rounded-2xl border-0 font-medium text-black"
-                disabled={!isDirty || isSaving || isLoading}
-              >
-                {isSaving ? (
-                  <>
-                    <div className="w-4 h-4 animate-spin border-2 border-current border-t-transparent rounded-full" />
-                    Saving...
-                  </>
-                ) : (
-                  "Save Changes"
-                )}
-              </TactileButton>
-
-              <Spacer y="xs" />
-
+            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm text-center">
               <p className="text-xs text-black/50">
                 Your personal information helps us provide a better workout experience. All data is stored securely.
               </p>

--- a/components/screens/profile/MyAccountScreen.tsx
+++ b/components/screens/profile/MyAccountScreen.tsx
@@ -1,0 +1,351 @@
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  type InputHTMLAttributes,
+} from "react";
+import { AppScreen, ScreenHeader, Section, Spacer, Stack } from "../../layouts";
+import { Avatar, AvatarFallback } from "../../ui/avatar";
+import { Input } from "../../ui/input";
+import { Label } from "../../ui/label";
+import { TactileButton } from "../../TactileButton";
+import { supabaseAPI, Profile } from "../../../utils/supabase/supabase-api";
+import { toast } from "sonner";
+import { logger } from "../../../utils/logging";
+
+interface MyAccountScreenProps {
+  onBack: () => void;
+}
+
+interface FormState {
+  displayName: string;
+  firstName: string;
+  lastName: string;
+  heightCm: string;
+  weightKg: string;
+}
+
+const emptyState: FormState = {
+  displayName: "",
+  firstName: "",
+  lastName: "",
+  heightCm: "",
+  weightKg: "",
+};
+
+export function MyAccountScreen({ onBack }: MyAccountScreenProps) {
+  const [formState, setFormState] = useState<FormState>(emptyState);
+  const [initialState, setInitialState] = useState<FormState>(emptyState);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      setIsLoading(true);
+      try {
+        const profile = await supabaseAPI.getMyProfile();
+        if (profile) {
+          const normalized = normalizeProfile(profile);
+          setFormState(normalized);
+          setInitialState(normalized);
+        } else {
+          setFormState(emptyState);
+          setInitialState(emptyState);
+        }
+      } catch (error) {
+        logger.error("Failed to load account profile:", error);
+        toast.error("Unable to load your profile right now.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadProfile();
+  }, []);
+
+  const displayName = useMemo(() => {
+    const trimmedDisplay = formState.displayName.trim();
+    if (trimmedDisplay) return trimmedDisplay;
+    const combined = [formState.firstName.trim(), formState.lastName.trim()]
+      .filter(Boolean)
+      .join(" ");
+    return combined || "User";
+  }, [formState.displayName, formState.firstName, formState.lastName]);
+
+  const initials = useMemo(() => {
+    const name = displayName;
+    if (!name) return "US";
+    const parts = name.split(" ").filter(Boolean);
+    if (parts.length >= 2) {
+      return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+    }
+    return name.slice(0, 2).toUpperCase();
+  }, [displayName]);
+
+  const isDirty = useMemo(() => {
+    return JSON.stringify(formState) !== JSON.stringify(initialState);
+  }, [formState, initialState]);
+
+  const handleChange = (field: keyof FormState) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setFormState((prev) => ({ ...prev, [field]: value }));
+    };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (isSaving || !isDirty) return;
+
+    const trimmedDisplayName = formState.displayName.trim();
+    const trimmedFirstName = formState.firstName.trim();
+    const trimmedLastName = formState.lastName.trim();
+
+    if (!trimmedDisplayName) {
+      toast.error("Display name is required.");
+      return;
+    }
+
+    const heightValue = parseOptionalNumber(formState.heightCm);
+    const weightValue = parseOptionalNumber(formState.weightKg);
+
+    if (heightValue !== undefined && heightValue <= 0) {
+      toast.error("Height must be a positive number.");
+      return;
+    }
+
+    if (weightValue !== undefined && weightValue <= 0) {
+      toast.error("Weight must be a positive number.");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const updated = await supabaseAPI.upsertProfile(
+        trimmedFirstName,
+        trimmedLastName,
+        trimmedDisplayName,
+        heightValue,
+        weightValue,
+      );
+
+      const nextState = updated ? normalizeProfile(updated) : {
+        displayName: trimmedDisplayName,
+        firstName: trimmedFirstName,
+        lastName: trimmedLastName,
+        heightCm: formState.heightCm,
+        weightKg: formState.weightKg,
+      };
+
+      setFormState(nextState);
+      setInitialState(nextState);
+      toast.success("Profile updated successfully.");
+    } catch (error) {
+      logger.error("Failed to update profile:", error);
+      toast.error("Could not save your changes. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <AppScreen
+      header={
+        <ScreenHeader
+          title="My Account"
+          onBack={onBack}
+          showBorder={false}
+          denseSmall
+          titleClassName="text-[17px] font-bold text-black"
+        />
+      }
+      maxContent="responsive"
+      showHeaderBorder={false}
+      showBottomBarBorder={false}
+      headerInScrollArea
+    >
+      <form onSubmit={handleSubmit} className="h-full">
+        <Stack gap="fluid">
+          <Section variant="plain" padding="none">
+            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm px-6 py-8 text-center shadow-sm">
+              <Avatar className="w-20 h-20 mx-auto mb-4 bg-primary text-black shadow-lg shadow-primary/30">
+                <AvatarFallback className="bg-primary text-black text-lg font-semibold">
+                  {initials}
+                </AvatarFallback>
+              </Avatar>
+
+              {isLoading ? (
+                <div className="flex items-center justify-center gap-2 text-sm text-black/60">
+                  <div className="w-4 h-4 animate-spin border-2 border-current border-t-transparent rounded-full" />
+                  Loading profile...
+                </div>
+              ) : (
+                <>
+                  <h1 className="text-[clamp(20px,5vw,26px)] font-semibold text-black mb-1">
+                    {displayName}
+                  </h1>
+                  <p className="text-sm text-black/60">
+                    Keep your details current to personalize your plan.
+                  </p>
+                </>
+              )}
+            </div>
+          </Section>
+
+          <Section variant="plain" padding="none">
+            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm space-y-6">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-black/60">
+                  Personal Information
+                </p>
+                <h2 className="mt-2 text-lg font-semibold text-black">
+                  How should we address you?
+                </h2>
+                <p className="text-sm text-black/60 mt-1">
+                  Update the details you&apos;d like to share with the community.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <Field
+                  label="Display Name"
+                  value={formState.displayName}
+                  onChange={handleChange("displayName")}
+                  placeholder="eg. Alex Johnson"
+                  required
+                  disabled={isLoading || isSaving}
+                />
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field
+                    label="First Name"
+                    value={formState.firstName}
+                    onChange={handleChange("firstName")}
+                    placeholder="First name"
+                    disabled={isLoading || isSaving}
+                  />
+                  <Field
+                    label="Last Name"
+                    value={formState.lastName}
+                    onChange={handleChange("lastName")}
+                    placeholder="Last name"
+                    disabled={isLoading || isSaving}
+                  />
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section variant="plain" padding="none">
+            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm space-y-6">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-black/60">
+                  Physical Information
+                </p>
+                <h2 className="mt-2 text-lg font-semibold text-black">
+                  Fitness stats help tailor your plan
+                </h2>
+                <p className="text-sm text-black/60 mt-1">
+                  Share optional stats to improve workout recommendations.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Field
+                  label="Height (cm)"
+                  value={formState.heightCm}
+                  onChange={handleChange("heightCm")}
+                  placeholder="eg. 175"
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  step="0.1"
+                  disabled={isLoading || isSaving}
+                />
+                <Field
+                  label="Weight (kg)"
+                  value={formState.weightKg}
+                  onChange={handleChange("weightKg")}
+                  placeholder="eg. 70"
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  step="0.1"
+                  disabled={isLoading || isSaving}
+                />
+              </div>
+            </div>
+          </Section>
+
+          <Section variant="plain" padding="none">
+            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm text-center space-y-4">
+              <TactileButton
+                type="submit"
+                className="w-full flex items-center justify-center gap-2 rounded-2xl border-0 font-medium text-black"
+                disabled={!isDirty || isSaving || isLoading}
+              >
+                {isSaving ? (
+                  <>
+                    <div className="w-4 h-4 animate-spin border-2 border-current border-t-transparent rounded-full" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save Changes"
+                )}
+              </TactileButton>
+
+              <Spacer y="xs" />
+
+              <p className="text-xs text-black/50">
+                Your personal information helps us provide a better workout experience. All data is stored securely.
+              </p>
+            </div>
+          </Section>
+        </Stack>
+      </form>
+    </AppScreen>
+  );
+}
+
+interface FieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+function Field({ label, className, ...inputProps }: FieldProps) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs font-semibold uppercase tracking-[0.18em] text-black/60">
+        {label}
+      </Label>
+      <Input
+        className={`bg-input-background border-border text-sm h-11 rounded-xl ${className ?? ""}`}
+        {...inputProps}
+      />
+    </div>
+  );
+}
+
+function normalizeProfile(profile: Profile): FormState {
+  return {
+    displayName: profile.display_name?.trim() ?? "",
+    firstName: profile.first_name?.trim() ?? "",
+    lastName: profile.last_name?.trim() ?? "",
+    heightCm:
+      profile.height_cm !== undefined && profile.height_cm !== null
+        ? String(profile.height_cm)
+        : "",
+    weightKg:
+      profile.weight_kg !== undefined && profile.weight_kg !== null
+        ? String(profile.weight_kg)
+        : "",
+  };
+}
+
+function parseOptionalNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return undefined;
+  return parsed;
+}

--- a/components/screens/profile/MyAccountScreen.tsx
+++ b/components/screens/profile/MyAccountScreen.tsx
@@ -185,7 +185,7 @@ export function MyAccountScreen({ onBack }: MyAccountScreenProps) {
         </BottomNavigation>
       }
       bottomBarSticky
-      headerInScrollArea
+      headerInScrollArea={false}
     >
       <form id={formId} onSubmit={handleSubmit} className="h-full">
         <Stack gap="fluid">
@@ -300,13 +300,6 @@ export function MyAccountScreen({ onBack }: MyAccountScreenProps) {
             </div>
           </Section>
 
-          <Section variant="plain" padding="none">
-            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm p-6 shadow-sm text-center">
-              <p className="text-xs text-black/50">
-                Your personal information helps us provide a better workout experience. All data is stored securely.
-              </p>
-            </div>
-          </Section>
         </Stack>
       </form>
     </AppScreen>

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -61,6 +61,16 @@ export function useAppNavigation() {
     }
   };
 
+  const showProfileAccount = () => {
+    setActiveTab("profile");
+    setCurrentView("profile-my-account");
+  };
+
+  const closeProfileAccount = () => {
+    setActiveTab("profile");
+    setCurrentView("profile");
+  };
+
   const showCreateRoutine = () => setCurrentView("create-routine");
   const showEditMeasurements = () => setCurrentView("edit-measurements");
 
@@ -175,5 +185,7 @@ export function useAppNavigation() {
     closeExerciseSetupToRoutines,
     handleUnauthorizedError,
     safeNavigate,
+    showProfileAccount,
+    closeProfileAccount,
   };
 }

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -71,6 +71,16 @@ export function useAppNavigation() {
     setCurrentView("profile");
   };
 
+  const showProfileAppSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile-app-settings");
+  };
+
+  const closeProfileAppSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile");
+  };
+
   const showCreateRoutine = () => setCurrentView("create-routine");
   const showEditMeasurements = () => setCurrentView("edit-measurements");
 
@@ -187,5 +197,7 @@ export function useAppNavigation() {
     safeNavigate,
     showProfileAccount,
     closeProfileAccount,
+    showProfileAppSettings,
+    closeProfileAppSettings,
   };
 }

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -9,7 +9,8 @@ export type AppView =
   | "edit-measurements"
 
   | "progress"
-  | "profile";
+  | "profile"
+  | "profile-my-account";
 
 export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "welcome",
@@ -20,6 +21,7 @@ export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "exercise-setup",
   "edit-measurements",
 
+  "profile-my-account",
 ];
 
 export type ViewType = AppView;

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -10,7 +10,8 @@ export type AppView =
 
   | "progress"
   | "profile"
-  | "profile-my-account";
+  | "profile-my-account"
+  | "profile-app-settings";
 
 export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "welcome",
@@ -22,6 +23,7 @@ export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "edit-measurements",
 
   "profile-my-account",
+  "profile-app-settings",
 ];
 
 export type ViewType = AppView;


### PR DESCRIPTION
## Summary
- turn profile navigation rows into buttons and wire the My Account entry into navigation
- add a dedicated MyAccountScreen for updating profile details and optional physical stats via Supabase
- extend the app router and navigation view map with the new profile-my-account view that hides the bottom nav

## Testing
- npm run test *(fails: existing Jest configuration cannot parse import.meta in utils/supabase/supabase-db-write.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cafee32968832194a90a7a1ed8141e