### PR TITLE
Add device settings screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -51,6 +51,8 @@ function AppContent() {
     closeExerciseSetupToRoutines,
     showProfileAccount,
     closeProfileAccount,
+    showProfileDeviceSettings,
+    closeProfileDeviceSettings,
   } = useAppNavigation();
 
   // ⬅️ now includes authReady
@@ -111,6 +113,8 @@ function AppContent() {
           onOverlayChange={setOverlayOpen}
           onNavigateToMyAccount={showProfileAccount}
           onCloseMyAccount={closeProfileAccount}
+          onNavigateToDeviceSettings={showProfileDeviceSettings}
+          onCloseDeviceSettings={closeProfileDeviceSettings}
         />
       </main>
     </div>

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -7,6 +7,7 @@ import EditMeasurementsScreen from "./screens/EditMeasurementsScreen";
 import { ProgressScreen } from "./screens/ProgressScreen";
 import { ProfileScreen } from "./screens/ProfileScreen";
 import { MyAccountScreen } from "./screens/profile/MyAccountScreen";
+import { DeviceSettingsScreen } from "./screens/profile/DeviceSettingsScreen";
 import { SignInScreen } from "./screens/SignInScreen";
 import { SignUpScreen } from "./screens/SignUpScreen";
 import { WelcomeScreen } from "./screens/WelcomeScreen";
@@ -59,6 +60,8 @@ interface AppRouterProps {
 
   onNavigateToMyAccount: () => void;
   onCloseMyAccount: () => void;
+  onNavigateToDeviceSettings: () => void;
+  onCloseDeviceSettings: () => void;
 }
 
 export function AppRouter({
@@ -99,6 +102,8 @@ export function AppRouter({
   onOverlayChange,
   onNavigateToMyAccount,
   onCloseMyAccount,
+  onNavigateToDeviceSettings,
+  onCloseDeviceSettings,
 }: AppRouterProps) {
   logger.debug(`🔍 [DBG] CURRENT SCREEN: ${currentView.toUpperCase()}`);
 
@@ -216,6 +221,7 @@ export function AppRouter({
         <ProfileScreen
           bottomBar={bottomBar}
           onNavigateToMyAccount={onNavigateToMyAccount}
+          onNavigateToDeviceSettings={onNavigateToDeviceSettings}
         />
       )}
 
@@ -225,6 +231,14 @@ export function AppRouter({
         exitTo="right"
       >
         <MyAccountScreen onBack={onCloseMyAccount} />
+      </SlideTransition>
+
+      <SlideTransition
+        show={currentView === "profile-device-settings"}
+        enterFrom="right"
+        exitTo="right"
+      >
+        <DeviceSettingsScreen onBack={onCloseDeviceSettings} />
       </SlideTransition>
     </div>
   );

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -25,9 +25,14 @@ import type { LucideIcon } from "lucide-react";
 interface ProfileScreenProps {
   bottomBar?: React.ReactNode;
   onNavigateToMyAccount?: () => void;
+  onNavigateToDeviceSettings?: () => void;
 }
 
-export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScreenProps) {
+export function ProfileScreen({
+  bottomBar,
+  onNavigateToMyAccount,
+  onNavigateToDeviceSettings,
+}: ProfileScreenProps) {
 
   const { userToken, signOut: authSignOut } = useAuth();
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -56,6 +61,7 @@ export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScree
           label: "Device Settings",
           description: "Manage Health Connect and devices",
           icon: Smartphone,
+          onPress: onNavigateToDeviceSettings,
         },
         {
           label: "Notifications",

--- a/components/screens/profile/DeviceSettingsScreen.tsx
+++ b/components/screens/profile/DeviceSettingsScreen.tsx
@@ -1,0 +1,423 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentType,
+  type SVGProps,
+} from "react";
+import { AppScreen, Stack } from "../../layouts";
+import { Switch } from "../../ui/switch";
+import { TactileButton } from "../../TactileButton";
+import { toast } from "sonner";
+import { cn } from "../../ui/utils";
+import {
+  Apple,
+  BrainCircuit,
+  Dumbbell,
+  Flame,
+  Footprints,
+  HeartPulse,
+  Route,
+} from "lucide-react";
+import type { HealthPermission, PermissionResponse } from "capacitor-health";
+import { logger } from "../../../utils/logging";
+
+interface DeviceSettingsScreenProps {
+  onBack: () => void;
+}
+
+type TrackedPermission =
+  | "READ_STEPS"
+  | "READ_ACTIVE_CALORIES"
+  | "READ_TOTAL_CALORIES"
+  | "READ_DISTANCE"
+  | "READ_HEART_RATE"
+  | "READ_WORKOUTS"
+  | "READ_MINDFULNESS";
+
+type PermissionStateMap = Record<TrackedPermission, boolean>;
+
+type PlatformKind = "ios" | "android" | "web" | "unknown";
+
+interface PermissionItem {
+  permission: TrackedPermission;
+  label: string;
+  description: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  iconClassName: string;
+}
+
+const TRACKED_PERMISSIONS: readonly TrackedPermission[] = [
+  "READ_STEPS",
+  "READ_ACTIVE_CALORIES",
+  "READ_TOTAL_CALORIES",
+  "READ_DISTANCE",
+  "READ_HEART_RATE",
+  "READ_WORKOUTS",
+  "READ_MINDFULNESS",
+];
+
+const TRACKED_PERMISSION_SET = new Set<TrackedPermission>(TRACKED_PERMISSIONS);
+
+const PERMISSION_ITEMS: PermissionItem[] = [
+  {
+    permission: "READ_STEPS",
+    label: "Steps",
+    description:
+      "Access your step count to track daily movement and progress against your goals.",
+    icon: Footprints,
+    iconClassName: "bg-sky-100 text-sky-600",
+  },
+  {
+    permission: "READ_ACTIVE_CALORIES",
+    label: "Active Energy",
+    description: "Track energy burned during workouts and active time to personalize training load.",
+    icon: Flame,
+    iconClassName: "bg-rose-100 text-rose-500",
+  },
+  {
+    permission: "READ_TOTAL_CALORIES",
+    label: "Dietary Energy",
+    description: "Compare calories consumed versus burned for a holistic view of your day.",
+    icon: Apple,
+    iconClassName: "bg-amber-100 text-amber-500",
+  },
+  {
+    permission: "READ_DISTANCE",
+    label: "Distance",
+    description: "Sync walking, running, cycling, and swim distances from Health.",
+    icon: Route,
+    iconClassName: "bg-emerald-100 text-emerald-500",
+  },
+  {
+    permission: "READ_HEART_RATE",
+    label: "Heart Rate",
+    description: "Monitor effort zones and recovery trends from your workouts.",
+    icon: HeartPulse,
+    iconClassName: "bg-rose-100 text-rose-500",
+  },
+  {
+    permission: "READ_WORKOUTS",
+    label: "Workouts",
+    description: "Import logged workouts to keep your history in one place.",
+    icon: Dumbbell,
+    iconClassName: "bg-purple-100 text-purple-500",
+  },
+  {
+    permission: "READ_MINDFULNESS",
+    label: "Mindfulness",
+    description: "Blend meditation minutes into your recovery and stress scores.",
+    icon: BrainCircuit,
+    iconClassName: "bg-indigo-100 text-indigo-500",
+  },
+];
+
+const STORAGE_KEY = "workitout.health-permissions";
+
+const createInitialState = (): PermissionStateMap =>
+  TRACKED_PERMISSIONS.reduce((acc, permission) => {
+    acc[permission] = false;
+    return acc;
+  }, {} as PermissionStateMap);
+
+const isTrackedPermission = (value: HealthPermission): value is TrackedPermission =>
+  TRACKED_PERMISSION_SET.has(value as TrackedPermission);
+
+export function DeviceSettingsScreen({ onBack }: DeviceSettingsScreenProps) {
+  const [permissionStates, setPermissionStates] = useState<PermissionStateMap>(createInitialState);
+  const [platform, setPlatform] = useState<PlatformKind>("unknown");
+  const [isLoading, setIsLoading] = useState(true);
+  const [busyPermission, setBusyPermission] = useState<TrackedPermission | "all" | null>(null);
+
+  const applyPermissionResponse = useCallback(
+    (response?: PermissionResponse) => {
+      if (!response?.permissions) return;
+      setPermissionStates((prev) => {
+        const next = { ...prev };
+        for (const entry of response.permissions) {
+          if (!entry) continue;
+          for (const [key, value] of Object.entries(entry)) {
+            const permission = key as HealthPermission;
+            if (isTrackedPermission(permission)) {
+              next[permission] = Boolean(value);
+            }
+          }
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const refreshPermissions = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const { Capacitor } = await import("@capacitor/core");
+      const currentPlatform = Capacitor.getPlatform() as PlatformKind;
+      const normalized: PlatformKind =
+        currentPlatform === "ios" || currentPlatform === "android" ? currentPlatform : "web";
+      setPlatform(normalized);
+
+      if (normalized === "android") {
+        const { Health } = await import("capacitor-health");
+        try {
+          const response = await Health.checkHealthPermissions({
+            permissions: [...TRACKED_PERMISSIONS],
+          });
+          applyPermissionResponse(response);
+        } catch (error) {
+          logger.warn("[device-settings] Failed to check Health Connect permissions", error);
+          toast.error("Unable to read Health Connect permission status.");
+        }
+      }
+
+      if (normalized === "ios") {
+        // iOS does not expose permission status programmatically.
+        logger.debug("[device-settings] Apple Health permissions cannot be checked directly");
+      }
+    } catch (error) {
+      logger.error("[device-settings] Unable to resolve platform", error);
+      toast.error("Unable to load device permissions.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [applyPermissionResponse]);
+
+  useEffect(() => {
+    // hydrate from local storage for platforms that do not expose status
+    if (typeof window === "undefined") return;
+    try {
+      const saved = window.localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved) as Partial<PermissionStateMap>;
+        setPermissionStates((prev) => ({ ...prev, ...parsed }));
+      }
+    } catch (error) {
+      logger.warn("[device-settings] Failed to read cached permissions", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshPermissions();
+  }, [refreshPermissions]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(permissionStates));
+    } catch (error) {
+      logger.warn("[device-settings] Failed to persist permission cache", error);
+    }
+  }, [permissionStates]);
+
+  const isNative = platform === "ios" || platform === "android";
+  const interactionsDisabled = isLoading || busyPermission !== null;
+  const activeBusyPermission =
+    busyPermission && busyPermission !== "all" ? busyPermission : null;
+
+  const handlePermissionToggle = useCallback(
+    async (permission: TrackedPermission, enable: boolean) => {
+      if (!isNative) {
+        toast.info("Connect an iOS or Android device to manage Health permissions.");
+        return;
+      }
+
+      setBusyPermission(permission);
+      try {
+        const { Health } = await import("capacitor-health");
+
+        if (enable) {
+          const response = await Health.requestHealthPermissions({ permissions: [permission] });
+          applyPermissionResponse(response);
+          toast.success(`${permissionLabel(permission)} enabled`);
+        } else {
+          if (platform === "ios") {
+            await Health.openAppleHealthSettings();
+            toast.info("Disable this permission from Apple Health > Access & Devices.");
+          } else {
+            await Health.openHealthConnectSettings();
+            toast.info("Disable this permission directly from Health Connect.");
+          }
+          setPermissionStates((prev) => ({ ...prev, [permission]: false }));
+        }
+      } catch (error) {
+        logger.error("[device-settings] Failed to update permission", error);
+        toast.error("Unable to update this permission right now.");
+      } finally {
+        setBusyPermission(null);
+        if (platform === "android") {
+          refreshPermissions();
+        }
+      }
+    },
+    [applyPermissionResponse, isNative, platform, refreshPermissions],
+  );
+
+  const handleAllowAll = useCallback(async () => {
+    if (!isNative) {
+      toast.info("Connect an iOS or Android device to manage Health permissions.");
+      return;
+    }
+
+    setBusyPermission("all");
+    try {
+      const { Health } = await import("capacitor-health");
+      const response = await Health.requestHealthPermissions({
+        permissions: [...TRACKED_PERMISSIONS],
+      });
+      applyPermissionResponse(response);
+      toast.success("Requested all available Health permissions.");
+    } catch (error) {
+      logger.error("[device-settings] Failed to request all permissions", error);
+      toast.error("Unable to update Health permissions.");
+    } finally {
+      setBusyPermission(null);
+      if (platform === "android") {
+        refreshPermissions();
+      }
+    }
+  }, [applyPermissionResponse, isNative, platform, refreshPermissions]);
+
+  const iosStatusNote = useMemo(() => {
+    if (platform !== "ios") return null;
+    return "Apple Health doesn't report the exact toggle states back to apps. We mirror your most recent choice. Use the Health app to confirm your final settings.";
+  }, [platform]);
+
+  const webNotice = useMemo(() => {
+    if (platform !== "web") return null;
+    return "Connect this app to an iOS or Android device to manage permissions.";
+  }, [platform]);
+
+  return (
+      <AppScreen
+      header={
+        <div className="flex items-center justify-between py-3 text-[15px]">
+          <button
+            type="button"
+            onClick={onBack}
+            className="font-medium text-black/60"
+          >
+            Don't Allow
+          </button>
+          <div className="text-[17px] font-semibold text-black">Health Access</div>
+          <button
+            type="button"
+            onClick={handleAllowAll}
+            disabled={interactionsDisabled}
+            className={cn(
+              "font-semibold text-primary transition-opacity",
+              interactionsDisabled && "opacity-40",
+            )}
+          >
+            Allow
+          </button>
+        </div>
+      }
+      showHeaderBorder={false}
+      showBottomBarBorder={false}
+      headerShellClassName="bg-white/70 backdrop-blur-xl"
+      padHeader
+      padContent={false}
+      maxContentPx={520}
+      contentClassName="px-4 pb-12 pt-6 sm:px-6"
+    >
+      <Stack gap="lg" className="mx-auto w-full">
+        <div className="rounded-3xl border border-border/60 bg-white/80 px-6 py-8 text-center shadow-sm backdrop-blur-md">
+          <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-3xl bg-rose-100 text-rose-500 shadow-inner">
+            <HeartPulse className="h-9 w-9" />
+          </div>
+          <h1 className="text-[22px] font-semibold text-black">Health</h1>
+          <p className="mt-2 text-sm text-black/60">
+            "Workout Tracker" would like to access and update your Health data.
+          </p>
+          <TactileButton
+            onClick={handleAllowAll}
+            disabled={interactionsDisabled}
+            className="mx-auto mt-5 w-full max-w-[220px]"
+          >
+            {busyPermission === "all" ? "Requesting..." : "Turn On All"}
+          </TactileButton>
+        </div>
+
+        <div className="rounded-3xl border border-border/60 bg-white/85 shadow-sm backdrop-blur-md">
+          <div className="border-b border-border/50 px-6 py-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-black/50">
+              Allow "Workout Tracker" to Read
+            </p>
+          </div>
+
+          <div className="divide-y divide-border/60">
+            {PERMISSION_ITEMS.map((item) => {
+              const checked = permissionStates[item.permission];
+              const disabled =
+                isLoading ||
+                busyPermission === "all" ||
+                (activeBusyPermission !== null && activeBusyPermission !== item.permission);
+              return (
+                <div
+                  key={item.permission}
+                  role="button"
+                  tabIndex={disabled ? -1 : 0}
+                  aria-disabled={disabled}
+                  className={cn(
+                    "flex w-full items-start gap-4 px-6 py-4 text-left transition-colors",
+                    !disabled && "hover:bg-black/5",
+                    disabled && "opacity-60",
+                  )}
+                  onClick={() => {
+                    if (disabled) return;
+                    handlePermissionToggle(item.permission, !checked);
+                  }}
+                  onKeyDown={(event) => {
+                    if (disabled) return;
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      handlePermissionToggle(item.permission, !checked);
+                    }
+                  }}
+                >
+                  <span
+                    className={cn(
+                      "mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-2xl text-[18px]", item.iconClassName,
+                    )}
+                  >
+                    <item.icon className="h-5 w-5" />
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span className="text-[15px] font-medium text-black">{item.label}</span>
+                    <span className="text-sm text-black/60">{item.description}</span>
+                  </span>
+                  <Switch
+                    checked={checked}
+                    onCheckedChange={(value) => handlePermissionToggle(item.permission, value)}
+                    disabled={disabled}
+                    onClick={(event) => event.stopPropagation()}
+                    aria-label={`Toggle ${item.label}`}
+                  />
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="px-6 py-4 text-sm text-black/60">
+            App Explanation: These permissions let WorkItOut sync steps, workouts, and recovery metrics so your plan stays accurate. You can adjust them anytime from Health settings.
+          </div>
+        </div>
+
+        {(iosStatusNote || webNotice) && (
+          <div className="rounded-3xl border border-dashed border-border/60 bg-white/60 px-6 py-4 text-sm text-black/60">
+            {iosStatusNote || webNotice}
+          </div>
+        )}
+      </Stack>
+    </AppScreen>
+  );
+}
+
+function permissionLabel(permission: TrackedPermission): string {
+  const item = PERMISSION_ITEMS.find((entry) => entry.permission === permission);
+  return item ? item.label : permission;
+}
+
+export default DeviceSettingsScreen;

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "./utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    ref={ref}
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-black/10 p-0.5 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 data-[state=checked]:bg-primary",
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 data-[state=checked]:translate-x-[18px] data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -71,6 +71,16 @@ export function useAppNavigation() {
     setCurrentView("profile");
   };
 
+  const showProfileDeviceSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile-device-settings");
+  };
+
+  const closeProfileDeviceSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile");
+  };
+
   const showCreateRoutine = () => setCurrentView("create-routine");
   const showEditMeasurements = () => setCurrentView("edit-measurements");
 
@@ -187,5 +197,7 @@ export function useAppNavigation() {
     safeNavigate,
     showProfileAccount,
     closeProfileAccount,
+    showProfileDeviceSettings,
+    closeProfileDeviceSettings,
   };
 }

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -10,7 +10,8 @@ export type AppView =
 
   | "progress"
   | "profile"
-  | "profile-my-account";
+  | "profile-my-account"
+  | "profile-device-settings";
 
 export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "welcome",
@@ -22,6 +23,7 @@ export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "edit-measurements",
 
   "profile-my-account",
+  "profile-device-settings",
 ];
 
 export type ViewType = AppView;


### PR DESCRIPTION
## Summary
- add an iOS-inspired Device Settings screen that requests health permissions and links into Apple Health / Health Connect
- create a reusable Switch UI component for permission toggles
- wire profile navigation and router/app navigation to surface the new screen

## Testing
- npm run build
- npm run test -- --runInBand *(fails: existing Jest config cannot parse import.meta in supabase DB utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4afecda08321add6c9a268df0a41