### PR TITLE
Add device settings screen for health permissions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -51,6 +51,8 @@ function AppContent() {
     closeExerciseSetupToRoutines,
     showProfileAccount,
     closeProfileAccount,
+    showProfileDeviceSettings,
+    closeProfileDeviceSettings,
   } = useAppNavigation();
 
   // ⬅️ now includes authReady
@@ -111,6 +113,8 @@ function AppContent() {
           onOverlayChange={setOverlayOpen}
           onNavigateToMyAccount={showProfileAccount}
           onCloseMyAccount={closeProfileAccount}
+          onNavigateToDeviceSettings={showProfileDeviceSettings}
+          onCloseDeviceSettings={closeProfileDeviceSettings}
         />
       </main>
     </div>

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -7,6 +7,7 @@ import EditMeasurementsScreen from "./screens/EditMeasurementsScreen";
 import { ProgressScreen } from "./screens/ProgressScreen";
 import { ProfileScreen } from "./screens/ProfileScreen";
 import { MyAccountScreen } from "./screens/profile/MyAccountScreen";
+import DeviceSettingsScreen from "./screens/profile/DeviceSettingsScreen";
 import { SignInScreen } from "./screens/SignInScreen";
 import { SignUpScreen } from "./screens/SignUpScreen";
 import { WelcomeScreen } from "./screens/WelcomeScreen";
@@ -59,6 +60,8 @@ interface AppRouterProps {
 
   onNavigateToMyAccount: () => void;
   onCloseMyAccount: () => void;
+  onNavigateToDeviceSettings: () => void;
+  onCloseDeviceSettings: () => void;
 }
 
 export function AppRouter({
@@ -99,6 +102,8 @@ export function AppRouter({
   onOverlayChange,
   onNavigateToMyAccount,
   onCloseMyAccount,
+  onNavigateToDeviceSettings,
+  onCloseDeviceSettings,
 }: AppRouterProps) {
   logger.debug(`🔍 [DBG] CURRENT SCREEN: ${currentView.toUpperCase()}`);
 
@@ -216,6 +221,7 @@ export function AppRouter({
         <ProfileScreen
           bottomBar={bottomBar}
           onNavigateToMyAccount={onNavigateToMyAccount}
+          onNavigateToDeviceSettings={onNavigateToDeviceSettings}
         />
       )}
 
@@ -225,6 +231,14 @@ export function AppRouter({
         exitTo="right"
       >
         <MyAccountScreen onBack={onCloseMyAccount} />
+      </SlideTransition>
+
+      <SlideTransition
+        show={currentView === "profile-device-settings"}
+        enterFrom="right"
+        exitTo="right"
+      >
+        <DeviceSettingsScreen onBack={onCloseDeviceSettings} />
       </SlideTransition>
     </div>
   );

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -25,9 +25,14 @@ import type { LucideIcon } from "lucide-react";
 interface ProfileScreenProps {
   bottomBar?: React.ReactNode;
   onNavigateToMyAccount?: () => void;
+  onNavigateToDeviceSettings?: () => void;
 }
 
-export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScreenProps) {
+export function ProfileScreen({
+  bottomBar,
+  onNavigateToMyAccount,
+  onNavigateToDeviceSettings,
+}: ProfileScreenProps) {
 
   const { userToken, signOut: authSignOut } = useAuth();
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -56,6 +61,7 @@ export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScree
           label: "Device Settings",
           description: "Manage Health Connect and devices",
           icon: Smartphone,
+          onPress: onNavigateToDeviceSettings,
         },
         {
           label: "Notifications",

--- a/components/screens/profile/DeviceSettingsScreen.tsx
+++ b/components/screens/profile/DeviceSettingsScreen.tsx
@@ -1,0 +1,333 @@
+import { useMemo } from "react";
+import {
+  AppScreen,
+  ScreenHeader,
+  Section,
+  Stack,
+} from "../../layouts";
+import { Card, CardContent } from "../../ui/card";
+import ListItem from "../../ui/ListItem";
+import { TactileButton } from "../../TactileButton";
+import {
+  Activity,
+  Brain,
+  Flame,
+  Footprints,
+  HeartPulse,
+  Route,
+  Ruler,
+  UtensilsCrossed,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { toast } from "sonner";
+import {
+  HEALTH_PERMISSION_IDS,
+  type HealthPermissionId,
+  type PermissionStatus,
+  useHealthPermissions,
+} from "../../../hooks/useHealthPermissions";
+import { cn } from "../../ui/utils";
+
+type DeviceSettingsScreenProps = {
+  onBack: () => void;
+};
+
+type PermissionMeta = {
+  id: HealthPermissionId;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  accent: string;
+};
+
+const PERMISSION_META: PermissionMeta[] = [
+  {
+    id: "READ_STEPS",
+    title: "Steps",
+    description: "Allow us to read your step count to keep your activity streak accurate.",
+    icon: Footprints,
+    accent: "bg-primary/20 text-black",
+  },
+  {
+    id: "READ_WORKOUTS",
+    title: "Workouts",
+    description: "Sync completed workouts so your training history stays up to date.",
+    icon: Activity,
+    accent: "bg-warm-peach/40 text-black",
+  },
+  {
+    id: "READ_ACTIVE_CALORIES",
+    title: "Active Energy",
+    description: "Track the calories you burn during movement for more accurate goals.",
+    icon: Flame,
+    accent: "bg-warm-coral/30 text-black",
+  },
+  {
+    id: "READ_TOTAL_CALORIES",
+    title: "Total Calories",
+    description: "Include resting energy to see your full daily calorie picture.",
+    icon: UtensilsCrossed,
+    accent: "bg-warm-cream/60 text-black",
+  },
+  {
+    id: "READ_DISTANCE",
+    title: "Distance",
+    description: "Import running, walking, and cycling distance for cardio sessions.",
+    icon: Ruler,
+    accent: "bg-warm-mint/40 text-black",
+  },
+  {
+    id: "READ_HEART_RATE",
+    title: "Heart Rate",
+    description: "Measure training intensity and recovery using heart rate trends.",
+    icon: HeartPulse,
+    accent: "bg-warm-rose/30 text-black",
+  },
+  {
+    id: "READ_ROUTE",
+    title: "Workout Routes",
+    description: "Attach GPS routes to outdoor workouts you log inside the app.",
+    icon: Route,
+    accent: "bg-accent-blue/20 text-black",
+  },
+  {
+    id: "READ_MINDFULNESS",
+    title: "Mindfulness",
+    description: "Import mindful minutes to balance your training with recovery.",
+    icon: Brain,
+    accent: "bg-warm-lavender/30 text-black",
+  },
+];
+
+const STATUS_LABELS: Record<PermissionStatus, string> = {
+  granted: "Enabled",
+  denied: "Disabled",
+  unknown: "Not requested",
+};
+
+const STATUS_COLORS: Record<PermissionStatus, string> = {
+  granted: "text-success",
+  denied: "text-destructive",
+  unknown: "text-black/50",
+};
+
+type PermissionToggleProps = {
+  checked: boolean;
+  disabled?: boolean;
+  loading?: boolean;
+  onCheckedChange: (next: boolean) => void;
+};
+
+function PermissionToggle({ checked, disabled, loading, onCheckedChange }: PermissionToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "relative h-7 w-[50px] rounded-full transition-all",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40",
+        checked ? "bg-primary" : "bg-black/20",
+        (disabled || loading) && "opacity-60 cursor-not-allowed",
+      )}
+    >
+      <span
+        className="absolute left-[4px] top-1/2 h-[22px] w-[22px] -translate-y-1/2 rounded-full bg-white shadow transition-transform"
+        style={{ transform: checked ? "translateX(22px)" : "translateX(0)" }}
+      />
+      {loading ? (
+        <span className="absolute inset-0 grid place-items-center">
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/70 border-t-transparent" />
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+export function DeviceSettingsScreen({ onBack }: DeviceSettingsScreenProps) {
+  const {
+    supported,
+    statuses,
+    isRefreshing,
+    pendingKey,
+    error,
+    refresh,
+    requestPermission,
+    requestAll,
+    openSystemSettings,
+  } = useHealthPermissions();
+
+  const permissionList = useMemo(() => {
+    const metaMap = new Map(PERMISSION_META.map((meta) => [meta.id, meta] as const));
+    return HEALTH_PERMISSION_IDS.map((id) => metaMap.get(id) ?? PERMISSION_META[0]!);
+  }, []);
+
+  const handleToggle = async (id: HealthPermissionId, next: boolean) => {
+    if (next) {
+      await requestPermission(id);
+      return;
+    }
+
+    const opened = await openSystemSettings();
+    if (opened) {
+      toast.info("Use the system settings to turn this permission off.");
+    } else {
+      toast.error("Unable to open system settings. Update permissions manually.");
+    }
+  };
+
+  const handleTurnOnAll = async () => {
+    const result = await requestAll();
+    if (result.success) {
+      toast.success("Requested all available health permissions.");
+    }
+  };
+
+  const handleRefresh = async () => {
+    await refresh();
+    toast.info("Permission status refreshed.");
+  };
+
+  return (
+    <AppScreen
+      header={
+        <ScreenHeader
+          title="Device Settings"
+          subtitle={supported ? "Manage Health access" : "Available on the mobile app"}
+          onBack={onBack}
+          denseSmall
+          showBorder
+        />
+      }
+      showHeaderBorder={false}
+      showBottomBarBorder={false}
+      bottomBar={null}
+      maxContent="responsive"
+      padHeader
+      padContent
+    >
+      <div className="pb-safe">
+        <Stack gap="fluid">
+          <Section variant="plain" padding="none">
+            <Card className="border border-border bg-card/80 backdrop-blur-sm shadow-sm">
+              <CardContent className="flex flex-col items-center gap-5 px-6 py-7 text-center">
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/30">
+                  <HeartPulse size={32} className="text-black" />
+                </div>
+                <div className="space-y-2">
+                  <h2 className="text-xl font-semibold text-black">Health Access</h2>
+                  <p className="text-sm text-black/70">
+                    "Workout Tracker" would like to access and update your Health data so your progress stays in sync.
+                  </p>
+                </div>
+                <div className="flex w-full flex-col gap-3 sm:flex-row">
+                  <TactileButton
+                    onClick={handleTurnOnAll}
+                    disabled={!supported || pendingKey === "ALL"}
+                    className="w-full sm:w-auto"
+                  >
+                    {pendingKey === "ALL" ? (
+                      <span className="flex items-center gap-2">
+                        <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                        Turning on…
+                      </span>
+                    ) : (
+                      "Turn On All"
+                    )}
+                  </TactileButton>
+                  <TactileButton
+                    variant="ghost"
+                    onClick={handleRefresh}
+                    disabled={!supported || isRefreshing}
+                    className="w-full justify-center rounded-2xl border border-border/50 bg-transparent text-sm sm:w-auto"
+                  >
+                    {isRefreshing ? (
+                      <span className="flex items-center gap-2 text-black">
+                        <span className="h-4 w-4 animate-spin rounded-full border-2 border-black/50 border-t-transparent" />
+                        Refreshing…
+                      </span>
+                    ) : (
+                      <span className="text-black">Refresh Status</span>
+                    )}
+                  </TactileButton>
+                </div>
+                {!supported ? (
+                  <p className="text-xs text-black/60">
+                    Health permissions are only available on the iOS or Android mobile app.
+                  </p>
+                ) : null}
+              </CardContent>
+            </Card>
+          </Section>
+
+          {error ? (
+            <Section variant="plain" padding="none">
+              <div className="rounded-3xl border border-warning/40 bg-warning-light/60 px-4 py-3 text-sm text-black">
+                {error}
+              </div>
+            </Section>
+          ) : null}
+
+          <Section variant="plain" padding="none">
+            <div className="rounded-3xl border border-border bg-card/80 backdrop-blur-sm">
+              <div className="divide-y divide-border/60">
+                {permissionList.map((permission) => {
+                  const status = statuses[permission.id];
+                  const pending = pendingKey === permission.id || pendingKey === "ALL";
+                  const isEnabled = status === "granted";
+
+                  return (
+                    <ListItem
+                      key={permission.id}
+                      leading={<permission.icon size={18} />}
+                      leadingClassName={cn(
+                        "w-12 h-12 rounded-2xl flex items-center justify-center",
+                        permission.accent,
+                      )}
+                      primary={permission.title}
+                      primaryClassName="text-sm font-semibold text-black"
+                      secondary={permission.description}
+                      secondaryClassName="text-xs text-black/60 mt-1"
+                      trailing={
+                        <div className="flex flex-col items-end gap-1">
+                          <PermissionToggle
+                            checked={isEnabled}
+                            disabled={!supported}
+                            loading={pending}
+                            onCheckedChange={(next) => handleToggle(permission.id, next)}
+                          />
+                          <span className={cn("text-[11px] font-medium", STATUS_COLORS[status])}>
+                            {STATUS_LABELS[status]}
+                          </span>
+                        </div>
+                      }
+                      className="px-4"
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          </Section>
+
+          <Section variant="plain" padding="none">
+            <div className="space-y-3 rounded-3xl border border-dashed border-border bg-card/60 px-5 py-4 text-xs text-black/70">
+              <p className="font-semibold uppercase tracking-[0.12em] text-black/70">App Explanation</p>
+              <p>
+                This app needs access to your movement and mindfulness data to personalize your plan, calculate daily activity,
+                and surface insights that help you reach your goals.
+              </p>
+              <p className="text-black/60">
+                You can turn off access anytime from Apple Health &gt; Access &amp; Devices &gt; Workout Tracker.
+              </p>
+            </div>
+          </Section>
+        </Stack>
+      </div>
+    </AppScreen>
+  );
+}
+
+export default DeviceSettingsScreen;
+

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -71,6 +71,16 @@ export function useAppNavigation() {
     setCurrentView("profile");
   };
 
+  const showProfileDeviceSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile-device-settings");
+  };
+
+  const closeProfileDeviceSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile");
+  };
+
   const showCreateRoutine = () => setCurrentView("create-routine");
   const showEditMeasurements = () => setCurrentView("edit-measurements");
 
@@ -187,5 +197,7 @@ export function useAppNavigation() {
     safeNavigate,
     showProfileAccount,
     closeProfileAccount,
+    showProfileDeviceSettings,
+    closeProfileDeviceSettings,
   };
 }

--- a/hooks/useHealthPermissions.ts
+++ b/hooks/useHealthPermissions.ts
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { HealthPermission } from "capacitor-health";
+import { logger } from "../utils/logging";
+
+type Platform = "ios" | "android" | "web" | string;
+
+const SUPPORTED_PLATFORMS = new Set<Platform>(["ios", "android"]);
+
+export const HEALTH_PERMISSION_IDS: readonly HealthPermission[] = [
+  "READ_STEPS",
+  "READ_WORKOUTS",
+  "READ_ACTIVE_CALORIES",
+  "READ_TOTAL_CALORIES",
+  "READ_DISTANCE",
+  "READ_HEART_RATE",
+  "READ_ROUTE",
+  "READ_MINDFULNESS",
+] as const;
+
+export type HealthPermissionId = (typeof HEALTH_PERMISSION_IDS)[number];
+
+export type PermissionStatus = "granted" | "denied" | "unknown";
+
+export type PermissionStatusMap = Record<HealthPermissionId, PermissionStatus>;
+
+const createDefaultStatus = (): PermissionStatusMap =>
+  HEALTH_PERMISSION_IDS.reduce((acc, id) => {
+    acc[id] = "unknown";
+    return acc;
+  }, {} as PermissionStatusMap);
+
+const DEFAULT_STATUS = createDefaultStatus();
+
+const boolToStatus = (value: boolean | undefined): PermissionStatus => {
+  if (value === true) return "granted";
+  if (value === false) return "denied";
+  return "unknown";
+};
+
+const normalizePermissionMap = (
+  response: unknown,
+): Partial<Record<HealthPermissionId, boolean>> => {
+  const target =
+    response && typeof response === "object"
+      ? (response as Record<string, unknown>).permissions ?? response
+      : undefined;
+
+  if (!target || typeof target !== "object") return {};
+
+  const result: Partial<Record<HealthPermissionId, boolean>> = {};
+
+  if (Array.isArray(target)) {
+    for (const entry of target) {
+      if (!entry || typeof entry !== "object") continue;
+      for (const [key, value] of Object.entries(entry)) {
+        if (HEALTH_PERMISSION_IDS.includes(key as HealthPermissionId) && typeof value === "boolean") {
+          result[key as HealthPermissionId] = value;
+        }
+      }
+    }
+    return result;
+  }
+
+  for (const [key, value] of Object.entries(target)) {
+    if (HEALTH_PERMISSION_IDS.includes(key as HealthPermissionId) && typeof value === "boolean") {
+      result[key as HealthPermissionId] = value;
+    }
+  }
+
+  return result;
+};
+
+const mapToStatus = (
+  map: Partial<Record<HealthPermissionId, boolean>>,
+): Partial<PermissionStatusMap> => {
+  const result: Partial<PermissionStatusMap> = {};
+  for (const key of HEALTH_PERMISSION_IDS) {
+    if (key in map) {
+      result[key] = boolToStatus(map[key]);
+    }
+  }
+  return result;
+};
+
+interface RequestResult {
+  success: boolean;
+}
+
+interface UseHealthPermissionsReturn {
+  platform: Platform;
+  supported: boolean;
+  statuses: PermissionStatusMap;
+  isRefreshing: boolean;
+  pendingKey: HealthPermissionId | "ALL" | null;
+  error: string | null;
+  refresh: () => Promise<void>;
+  requestPermission: (permission: HealthPermissionId) => Promise<RequestResult>;
+  requestAll: () => Promise<RequestResult>;
+  openSystemSettings: () => Promise<boolean>;
+}
+
+export function useHealthPermissions(): UseHealthPermissionsReturn {
+  const [platform, setPlatform] = useState<Platform>("web");
+  const [isReady, setIsReady] = useState(false);
+  const [statuses, setStatuses] = useState<PermissionStatusMap>(() => ({ ...DEFAULT_STATUS }));
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [pendingKey, setPendingKey] = useState<HealthPermissionId | "ALL" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const supported = useMemo(() => SUPPORTED_PLATFORMS.has(platform), [platform]);
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      try {
+        const { Capacitor } = await import("@capacitor/core");
+        const nextPlatform = Capacitor.getPlatform();
+        if (active) setPlatform(nextPlatform);
+      } catch {
+        if (active) setPlatform("web");
+      } finally {
+        if (active) setIsReady(true);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!supported) {
+      setStatuses({ ...DEFAULT_STATUS });
+    }
+  }, [supported]);
+
+  const refresh = useCallback(async () => {
+    if (!isReady) return;
+    if (!supported) return;
+
+    setIsRefreshing(true);
+    setError(null);
+
+    try {
+      const { Health } = await import("capacitor-health");
+
+      if (platform === "android" && typeof Health.checkHealthPermissions === "function") {
+        const response = await Health.checkHealthPermissions({ permissions: [...HEALTH_PERMISSION_IDS] });
+        const parsed = mapToStatus(normalizePermissionMap(response));
+        if (Object.keys(parsed).length > 0) {
+          setStatuses((prev) => ({ ...prev, ...parsed }));
+        }
+      }
+    } catch (err) {
+      logger.warn("[device-settings] Failed to refresh health permissions", err);
+      setError("Unable to verify your current permissions. Try toggling them again.");
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [isReady, platform, supported]);
+
+  useEffect(() => {
+    if (!isReady) return;
+    void refresh();
+  }, [isReady, refresh]);
+
+  const requestMany = useCallback(
+    async (keys: HealthPermissionId[]): Promise<RequestResult> => {
+      if (!supported) {
+        setError("Health permissions are only available on the mobile app.");
+        return { success: false };
+      }
+
+      setPendingKey(keys.length === 1 ? keys[0] : "ALL");
+      setError(null);
+
+      try {
+        const { Health } = await import("capacitor-health");
+        const response = await Health.requestHealthPermissions({ permissions: keys });
+        const parsed = mapToStatus(normalizePermissionMap(response));
+
+        if (Object.keys(parsed).length > 0) {
+          setStatuses((prev) => ({ ...prev, ...parsed }));
+        } else if (platform === "ios") {
+          // iOS does not report granular results; assume granted on success.
+          const assumed: Partial<PermissionStatusMap> = {};
+          keys.forEach((key) => {
+            assumed[key] = "granted";
+          });
+          setStatuses((prev) => ({ ...prev, ...assumed }));
+        }
+
+        if (platform === "android") {
+          await refresh();
+        }
+
+        return { success: true };
+      } catch (err) {
+        logger.error("[device-settings] Permission request failed", err);
+        setError("We couldn't update that permission. Please try again.");
+        return { success: false };
+      } finally {
+        setPendingKey(null);
+      }
+    },
+    [platform, refresh, supported],
+  );
+
+  const openSystemSettings = useCallback(async () => {
+    if (!supported) return false;
+
+    try {
+      const { Health } = await import("capacitor-health");
+
+      if (platform === "ios" && typeof Health.openAppleHealthSettings === "function") {
+        await Health.openAppleHealthSettings();
+        return true;
+      }
+
+      if (platform === "android" && typeof Health.openHealthConnectSettings === "function") {
+        await Health.openHealthConnectSettings();
+        return true;
+      }
+
+      return false;
+    } catch (err) {
+      logger.warn("[device-settings] Failed to open system settings", err);
+      setError("Unable to open the system settings on this device.");
+      return false;
+    }
+  }, [platform, supported]);
+
+  const requestPermission = useCallback(
+    (permission: HealthPermissionId) => requestMany([permission]),
+    [requestMany],
+  );
+
+  const requestAll = useCallback(() => requestMany([...HEALTH_PERMISSION_IDS]), [requestMany]);
+
+  return {
+    platform,
+    supported,
+    statuses,
+    isRefreshing,
+    pendingKey,
+    error,
+    refresh,
+    requestPermission,
+    requestAll,
+    openSystemSettings,
+  };
+}
+

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -10,7 +10,8 @@ export type AppView =
 
   | "progress"
   | "profile"
-  | "profile-my-account";
+  | "profile-my-account"
+  | "profile-device-settings";
 
 export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "welcome",
@@ -22,6 +23,7 @@ export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "edit-measurements",
 
   "profile-my-account",
+  "profile-device-settings",
 ];
 
 export type ViewType = AppView;


### PR DESCRIPTION
## Summary
- add a dedicated Device Settings screen that mirrors the iOS Health permission prompt with rich copy, toggle rows, and actions to turn on all permissions or refresh status
- introduce a reusable useHealthPermissions hook to request or check Capacitor health permissions and to open native settings when revoking access
- wire the new screen into profile navigation and update view routing so the bottom navigation hides appropriately when viewing device permissions

## Testing
- `npm run test` *(fails: existing Jest configuration cannot parse project files using import.meta)*
- `npx tsc --noEmit` *(fails: repository already contains numerous TypeScript type errors outside the new changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4afecda08321add6c9a268df0a41