### PR TITLE
Add device settings screen to profile

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -51,6 +51,8 @@ function AppContent() {
     closeExerciseSetupToRoutines,
     showProfileAccount,
     closeProfileAccount,
+    showProfileDeviceSettings,
+    closeProfileDeviceSettings,
   } = useAppNavigation();
 
   // ⬅️ now includes authReady
@@ -111,6 +113,8 @@ function AppContent() {
           onOverlayChange={setOverlayOpen}
           onNavigateToMyAccount={showProfileAccount}
           onCloseMyAccount={closeProfileAccount}
+          onNavigateToDeviceSettings={showProfileDeviceSettings}
+          onCloseDeviceSettings={closeProfileDeviceSettings}
         />
       </main>
     </div>

--- a/components/AppRouter.tsx
+++ b/components/AppRouter.tsx
@@ -7,6 +7,7 @@ import EditMeasurementsScreen from "./screens/EditMeasurementsScreen";
 import { ProgressScreen } from "./screens/ProgressScreen";
 import { ProfileScreen } from "./screens/ProfileScreen";
 import { MyAccountScreen } from "./screens/profile/MyAccountScreen";
+import { DeviceSettingsScreen } from "./screens/profile/DeviceSettingsScreen";
 import { SignInScreen } from "./screens/SignInScreen";
 import { SignUpScreen } from "./screens/SignUpScreen";
 import { WelcomeScreen } from "./screens/WelcomeScreen";
@@ -59,6 +60,8 @@ interface AppRouterProps {
 
   onNavigateToMyAccount: () => void;
   onCloseMyAccount: () => void;
+  onNavigateToDeviceSettings: () => void;
+  onCloseDeviceSettings: () => void;
 }
 
 export function AppRouter({
@@ -99,6 +102,8 @@ export function AppRouter({
   onOverlayChange,
   onNavigateToMyAccount,
   onCloseMyAccount,
+  onNavigateToDeviceSettings,
+  onCloseDeviceSettings,
 }: AppRouterProps) {
   logger.debug(`🔍 [DBG] CURRENT SCREEN: ${currentView.toUpperCase()}`);
 
@@ -216,6 +221,7 @@ export function AppRouter({
         <ProfileScreen
           bottomBar={bottomBar}
           onNavigateToMyAccount={onNavigateToMyAccount}
+          onNavigateToDeviceSettings={onNavigateToDeviceSettings}
         />
       )}
 
@@ -225,6 +231,14 @@ export function AppRouter({
         exitTo="right"
       >
         <MyAccountScreen onBack={onCloseMyAccount} />
+      </SlideTransition>
+
+      <SlideTransition
+        show={currentView === "profile-device-settings"}
+        enterFrom="right"
+        exitTo="right"
+      >
+        <DeviceSettingsScreen onBack={onCloseDeviceSettings} />
       </SlideTransition>
     </div>
   );

--- a/components/screens/ProfileScreen.tsx
+++ b/components/screens/ProfileScreen.tsx
@@ -25,9 +25,14 @@ import type { LucideIcon } from "lucide-react";
 interface ProfileScreenProps {
   bottomBar?: React.ReactNode;
   onNavigateToMyAccount?: () => void;
+  onNavigateToDeviceSettings?: () => void;
 }
 
-export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScreenProps) {
+export function ProfileScreen({
+  bottomBar,
+  onNavigateToMyAccount,
+  onNavigateToDeviceSettings,
+}: ProfileScreenProps) {
 
   const { userToken, signOut: authSignOut } = useAuth();
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -56,6 +61,7 @@ export function ProfileScreen({ bottomBar, onNavigateToMyAccount }: ProfileScree
           label: "Device Settings",
           description: "Manage Health Connect and devices",
           icon: Smartphone,
+          onPress: onNavigateToDeviceSettings,
         },
         {
           label: "Notifications",

--- a/components/screens/profile/DeviceSettingsScreen.tsx
+++ b/components/screens/profile/DeviceSettingsScreen.tsx
@@ -1,0 +1,125 @@
+import { AppScreen, ScreenHeader, Section, Stack } from "../../layouts";
+import { Card } from "../../ui/card";
+import { TactileButton } from "../../TactileButton";
+import {
+  Activity,
+  Flame,
+  Footprints,
+  HeartPulse,
+  Moon,
+  Sparkles,
+} from "lucide-react";
+
+interface DeviceSettingsScreenProps {
+  onBack: () => void;
+}
+
+export function DeviceSettingsScreen({ onBack }: DeviceSettingsScreenProps) {
+  const featureIcons = [HeartPulse, Moon, Footprints, Activity, Flame, Sparkles];
+
+  return (
+    <AppScreen
+      className="bg-gradient-to-b from-[var(--soft-gray)] via-[var(--background)] to-[var(--warm-cream)]/60 text-black"
+      header={
+        <ScreenHeader
+          title="Device Settings"
+          onBack={onBack}
+          showBorder={false}
+          denseSmall
+          titleClassName="text-[17px] font-bold text-black"
+        />
+      }
+      maxContent="responsive"
+      showHeaderBorder={false}
+      showBottomBarBorder={false}
+      headerInScrollArea
+      padContent={false}
+    >
+      <div className="px-4 py-6 sm:px-6 md:px-8 md:py-8">
+        <Stack gap="fluid">
+          <Section variant="plain" padding="none">
+            <Card className="relative overflow-hidden rounded-3xl border border-border/80 bg-card/90 px-6 py-8 text-center shadow-md">
+              <div className="pointer-events-none absolute -right-16 -top-16 h-40 w-40 rounded-full bg-primary/10" />
+              <div className="pointer-events-none absolute -left-12 bottom-0 h-32 w-32 rounded-full bg-accent/10" />
+
+              <div className="relative flex items-center justify-center gap-4">
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white shadow-lg shadow-black/5">
+                  <HeartPulse className="h-8 w-8 text-[#ff3b30]" strokeWidth={1.6} />
+                </div>
+                <div className="h-px w-10 bg-black/10" />
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary text-black shadow-lg shadow-primary/30">
+                  <span className="text-lg font-semibold">WI</span>
+                </div>
+              </div>
+
+              <div className="mt-6 grid grid-cols-3 gap-3 sm:grid-cols-6">
+                {featureIcons.map((Icon, index) => (
+                  <div
+                    key={Icon.displayName ?? Icon.name ?? index}
+                    className="flex h-10 w-full items-center justify-center rounded-xl border border-border/60 bg-white/70 text-primary"
+                  >
+                    <Icon className="h-5 w-5" strokeWidth={1.8} />
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-8 space-y-3">
+                <h1 className="text-[clamp(20px,5vw,26px)] font-semibold">
+                  Connect WorkItOut with Apple Health
+                </h1>
+                <p className="text-sm text-black/70">
+                  Syncing your Apple Health data—from sleep to steps—helps WorkItOut
+                  personalize your training and build smarter guidance over time.
+                </p>
+              </div>
+
+              <div className="mt-8 space-y-2 text-sm text-black/60">
+                <p>
+                  You can update these permissions anytime in your device settings.
+                  Head to <span className="font-medium text-black">Settings &gt; Apps &gt; Health</span>,
+                  then choose <span className="font-medium text-black">Data Access &amp; Devices</span>.
+                </p>
+                <p>
+                  Select <span className="font-medium text-black">WorkItOut</span> and enable the metrics you want to share.
+                </p>
+              </div>
+
+              <div className="mt-8">
+                <TactileButton
+                  variant="primary"
+                  className="w-full justify-center rounded-2xl text-sm font-semibold"
+                  type="button"
+                >
+                  Learn More
+                </TactileButton>
+              </div>
+            </Card>
+          </Section>
+
+          <Section
+            variant="translucent"
+            padding="lg"
+            className="rounded-3xl border border-border/60 shadow-sm"
+          >
+            <Stack gap="sm">
+              <h2 className="text-base font-semibold text-black">
+                Why connect your devices?
+              </h2>
+              <ul className="space-y-3 text-sm text-black/70">
+                <li>
+                  Tailored recovery reminders based on your real rest and activity data.
+                </li>
+                <li>
+                  Richer progress insights that highlight trends across workouts, sleep, and energy.
+                </li>
+                <li>
+                  Smarter coaching moments when WorkItOut notices meaningful changes.
+                </li>
+              </ul>
+            </Stack>
+          </Section>
+        </Stack>
+      </div>
+    </AppScreen>
+  );
+}

--- a/hooks/useAppNavigation.ts
+++ b/hooks/useAppNavigation.ts
@@ -71,6 +71,16 @@ export function useAppNavigation() {
     setCurrentView("profile");
   };
 
+  const showProfileDeviceSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile-device-settings");
+  };
+
+  const closeProfileDeviceSettings = () => {
+    setActiveTab("profile");
+    setCurrentView("profile");
+  };
+
   const showCreateRoutine = () => setCurrentView("create-routine");
   const showEditMeasurements = () => setCurrentView("edit-measurements");
 
@@ -187,5 +197,7 @@ export function useAppNavigation() {
     safeNavigate,
     showProfileAccount,
     closeProfileAccount,
+    showProfileDeviceSettings,
+    closeProfileDeviceSettings,
   };
 }

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -10,7 +10,8 @@ export type AppView =
 
   | "progress"
   | "profile"
-  | "profile-my-account";
+  | "profile-my-account"
+  | "profile-device-settings";
 
 export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "welcome",
@@ -22,6 +23,7 @@ export const VIEWS_WITHOUT_BOTTOM_NAV: AppView[] = [
   "edit-measurements",
 
   "profile-my-account",
+  "profile-device-settings",
 ];
 
 export type ViewType = AppView;


### PR DESCRIPTION
## Summary
- add a dedicated device settings screen that mirrors the Apple Health messaging in the WorkItOut visual style
- connect the Profile screen navigation to open the new device settings view with slide transition handling
- extend shared navigation utilities so the new screen hides the bottom navigation and supports returning to the profile hub

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd43eda52c832194e703d864592262