### PR TITLE
Respect unit preferences for profile, measurements, and workouts

### DIFF
--- a/components/measurements/MeasurementCard.tsx
+++ b/components/measurements/MeasurementCard.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import ExpandingCard from "../ui/ExpandingCard";
 import { NumberInput } from "../ui/number-input";
 import { Minus, Plus } from "lucide-react";
+import { formatNumber } from "../../utils/unitConversion";
 
 interface MeasurementEntry {
   date: string;
@@ -25,7 +26,8 @@ export default function MeasurementCard({
 }: MeasurementCardProps) {
   const [expanded, setExpanded] = useState(false);
 
-  const step = 0.5;
+  const step = useMemo(() => (unit === "m" ? 0.01 : 0.5), [unit]);
+  const diffPrecision = unit === "m" ? 2 : 1;
   const parse = (v: string) => {
     const n = parseFloat(v);
     return isNaN(n) ? 0 : n;
@@ -53,7 +55,9 @@ export default function MeasurementCard({
       ? parse(entries[0]?.value ?? "0") - parse(entries[1].value)
       : null;
   const diffText =
-    diff != null ? `${diff >= 0 ? "+" : ""}${diff.toFixed(1)}${unit}` : undefined;
+    diff != null
+      ? `${diff >= 0 ? "+" : ""}${formatNumber(diff, diffPrecision)}${unit}`
+      : undefined;
 
   return (
     <ExpandingCard

--- a/components/screens/EditMeasurementsScreen.tsx
+++ b/components/screens/EditMeasurementsScreen.tsx
@@ -3,13 +3,21 @@ import { BottomNavigation } from "../BottomNavigation";
 import { BottomNavigationButton } from "../BottomNavigationButton";
 import { toast } from "sonner";
 import MeasurementCard from "../measurements/MeasurementCard";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { supabaseAPI } from "../../utils/supabase/supabase-api";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { supabaseAPI, type UnitLength } from "../../utils/supabase/supabase-api";
 import {
   collapseMeasurementJournal,
   makeMeasurementJournal,
   recordMeasurementUpdate,
 } from "../measurements/measurementJournal";
+import { logger } from "../../utils/logging";
+import {
+  DEFAULT_LENGTH_UNIT,
+  formatLength,
+  getLengthUnitLabel,
+  normalizeLengthUnit,
+  parseLengthInput,
+} from "../../utils/unitConversion";
 
 interface EditMeasurementsScreenProps {
   onBack: () => void;
@@ -35,9 +43,10 @@ type MeasurementEntry = { measured_on: string } & Record<PartKey, string>;
 export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScreenProps) {
   const [entries, setEntries] = useState<MeasurementEntry[]>([]);
   const [hasTodayEntry, setHasTodayEntry] = useState(true);
+  const [lengthUnit, setLengthUnit] = useState<UnitLength>(DEFAULT_LENGTH_UNIT);
   const journalRef = useRef(makeMeasurementJournal());
   const savedSnapshotRef = useRef<MeasurementEntry[]>([]);
-  const loadEntries = async () => {
+  const loadEntries = useCallback(async (unit: UnitLength) => {
     const rows = await supabaseAPI.getBodyMeasurements(4);
     const today = new Date().toISOString().split("T")[0];
     const existingToday = rows.some((r) => r.measured_on === today);
@@ -47,7 +56,9 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
       const newRow: any = { measured_on: today };
       measurementParts.forEach((part) => {
         newRow[part.key] =
-          last && last[part.key] != null ? String(last[part.key]) : "";
+          last && last[part.key] != null
+            ? formatLength(Number(last[part.key]), unit)
+            : "";
       });
       data = [newRow, ...rows];
     }
@@ -60,7 +71,8 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
     const mapped = data.map((r) => {
       const obj: any = { measured_on: r.measured_on };
       measurementParts.forEach((part) => {
-        obj[part.key] = r[part.key] != null ? String(r[part.key]) : "";
+        obj[part.key] =
+          r[part.key] != null ? formatLength(Number(r[part.key]), unit) : "";
       });
       return obj as MeasurementEntry;
     });
@@ -68,11 +80,34 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
     journalRef.current = makeMeasurementJournal();
     setEntries(mapped);
     setHasTodayEntry(existingToday);
-  };
+  }, []);
 
   useEffect(() => {
-    loadEntries();
-  }, []);
+    let cancelled = false;
+    const fetchUnitsAndEntries = async () => {
+      try {
+        const profile = await supabaseAPI.getMyProfile();
+        if (cancelled) return;
+        const preferredUnit = normalizeLengthUnit(profile?.length_unit);
+        setLengthUnit(preferredUnit);
+        await loadEntries(preferredUnit);
+      } catch (error) {
+        logger.error("Failed to load measurement preferences", error);
+        if (!cancelled) {
+          setLengthUnit(DEFAULT_LENGTH_UNIT);
+          await loadEntries(DEFAULT_LENGTH_UNIT);
+        }
+      } finally {
+        // no-op
+      }
+    };
+
+    fetchUnitsAndEntries();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadEntries]);
 
   const handleSave = async () => {
     const collapsed = collapseMeasurementJournal(journalRef.current);
@@ -90,15 +125,15 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
     for (const [date, parts] of Object.entries(collapsed)) {
       const payload: Record<string, any> = { measured_on: date };
       for (const [key, value] of Object.entries(parts)) {
-        const num = parseFloat(value);
-        if (!isNaN(num)) payload[key] = num;
+        const parsed = parseLengthInput(value, lengthUnit);
+        if (parsed !== undefined && !isNaN(parsed)) payload[key] = parsed;
       }
       if (Object.keys(payload).length > 1) {
         await supabaseAPI.upsertBodyMeasurement(payload as any);
       }
     }
     journalRef.current = makeMeasurementJournal();
-    await loadEntries();
+    await loadEntries(lengthUnit);
     toast.success("Measurements saved");
     onBack();
   };
@@ -146,6 +181,7 @@ export default function EditMeasurementsScreen({ onBack }: EditMeasurementsScree
             <MeasurementCard
               label={m.label}
               icon={m.icon}
+              unit={getLengthUnitLabel(lengthUnit)}
               entries={entries.map((e) => ({ date: e.measured_on, value: e[m.key] || "" }))}
               onEntryChange={(index, value) =>
                 setEntries((prev) => {

--- a/components/screens/ExerciseSetupScreen.tsx
+++ b/components/screens/ExerciseSetupScreen.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "../AuthContext";
 import {
   Exercise,
   supabaseAPI,
+  type UnitWeight,
   type UserRoutineExerciseSet,
 } from "../../utils/supabase/supabase-api";
 import { logger } from "../../utils/logging";
@@ -19,6 +20,13 @@ import { loadRoutineExercisesWithSets, SETS_PREFETCH_CONCURRENCY } from "../../u
 import ListItem from "../ui/ListItem";
 import ActionSheet from "../sheets/ActionSheet";
 import { useAppStateSaver } from "../../utils/appState";
+import {
+  DEFAULT_WEIGHT_UNIT,
+  formatWeight,
+  getWeightUnitLabel,
+  normalizeWeightUnit,
+  weightUnitToKg,
+} from "../../utils/unitConversion";
 
 // --- Journal-based persistence (simple, testable) ---
 import {
@@ -99,6 +107,9 @@ export function ExerciseSetupScreen({
 }: ExerciseSetupScreenProps) {
   const { userToken } = useAuth();
 
+  const [weightUnit, setWeightUnit] = useState<UnitWeight>(DEFAULT_WEIGHT_UNIT);
+  const [weightUnitReady, setWeightUnitReady] = useState(false);
+  const previousWeightUnitRef = useRef<UnitWeight>(DEFAULT_WEIGHT_UNIT);
   const [exercises, setExercises] = useState<UIExercise[]>([]);
   const [loadingSaved, setLoadingSaved] = useState(true);
   const [savingAll, setSavingAll] = useState(false);
@@ -121,6 +132,83 @@ export function ExerciseSetupScreen({
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const workoutStartRef = useRef<number | null>(null);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadPreferences = async () => {
+      if (!userToken) {
+        if (!cancelled) {
+          setWeightUnit(DEFAULT_WEIGHT_UNIT);
+          previousWeightUnitRef.current = DEFAULT_WEIGHT_UNIT;
+          setWeightUnitReady(true);
+        }
+        return;
+      }
+      try {
+        const profile = await supabaseAPI.getMyProfile();
+        if (cancelled) return;
+        const preferredUnit = normalizeWeightUnit(profile?.weight_unit);
+        setWeightUnit(preferredUnit);
+        previousWeightUnitRef.current = preferredUnit;
+      } catch (error) {
+        if (!cancelled) {
+          logger.error("Failed to load weight unit preference", error);
+        }
+      } finally {
+        if (!cancelled) {
+          setWeightUnitReady(true);
+        }
+      }
+    };
+
+    loadPreferences();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userToken]);
+
+  const weightUnitLabel = useMemo(
+    () => getWeightUnitLabel(weightUnit).toUpperCase(),
+    [weightUnit]
+  );
+
+  const toDisplayWeight = useCallback(
+    (value: number | string | null | undefined): string => {
+      const numeric =
+        typeof value === "number"
+          ? value
+          : value != null && value !== ""
+          ? Number(value)
+          : 0;
+      if (!Number.isFinite(numeric)) return "0";
+      const formatted = formatWeight(numeric, weightUnit);
+      return formatted !== "" ? formatted : "0";
+    },
+    [weightUnit]
+  );
+
+  useEffect(() => {
+    if (!weightUnitReady) return;
+    const previousUnit = previousWeightUnitRef.current;
+    if (previousUnit === weightUnit) return;
+
+    setExercises((prev) =>
+      prev.map((exercise) => ({
+        ...exercise,
+        sets: exercise.sets.map((set) => {
+          const numeric = Number(set.weight);
+          if (!Number.isFinite(numeric)) {
+            return { ...set, weight: "0" };
+          }
+          const weightKg = weightUnitToKg(numeric, previousUnit);
+          const formatted = formatWeight(weightKg, weightUnit);
+          return { ...set, weight: formatted !== "" ? formatted : "0" };
+        }),
+      }))
+    );
+    previousWeightUnitRef.current = weightUnit;
+  }, [weightUnit, weightUnitReady]);
 
   type SaverState = {
     exercises: UIExercise[];
@@ -239,7 +327,7 @@ export function ExerciseSetupScreen({
      Load saved exercises using routineLoader
      ------------------------------------------------------------------------------------- */
   useEffect(() => {
-    if (!userToken) return;
+    if (!userToken || !weightUnitReady) return;
     // If state was restored from app-state cache, skip fetching
     if (exercises.length > 0) {
       setLoadingSaved(false);
@@ -265,7 +353,10 @@ export function ExerciseSetupScreen({
           loaded: true,
           expanded: false,
           completed: false,
-          sets: r.sets,
+          sets: r.sets.map((set) => ({
+            ...set,
+            weight: toDisplayWeight(set.weight),
+          })),
         }));
         setExercises(uiList);
         savedSnapshotRef.current = snapshotExercises(uiList);
@@ -281,7 +372,7 @@ export function ExerciseSetupScreen({
     return () => {
       cancelled = true;
     };
-  }, [routineId, userToken]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [routineId, userToken, weightUnitReady, toDisplayWeight]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /* -------------------------------------------------------------------------------------
      Add selected exercises AFTER initial load completes
@@ -341,7 +432,7 @@ export function ExerciseSetupScreen({
           id: r.routine_template_exercise_set_id,
           set_order: r.set_order ?? 0,
           reps: String(r.planned_reps ?? "0"),
-          weight: String(r.planned_weight_kg ?? "0"),
+          weight: toDisplayWeight(r.planned_weight_kg),
         }));
 
       withExercises((draft) => {
@@ -653,7 +744,7 @@ export function ExerciseSetupScreen({
       }
       const plan = collapseJournal(journal);
       if (!journalIsNoop(journal)) {
-        await runJournal(plan, routineId, exIdMap);
+        await runJournal(plan, routineId, exIdMap, weightUnit);
       }
       journalRef.current = makeJournal();
 
@@ -694,7 +785,10 @@ export function ExerciseSetupScreen({
         loaded: true,
         expanded: false,
         completed: false,
-        sets: r.sets,
+        sets: r.sets.map((set) => ({
+          ...set,
+          weight: toDisplayWeight(set.weight),
+        })),
       }));
       setExercises(uiList);
       savedSnapshotRef.current = snapshotExercises(uiList);
@@ -726,7 +820,7 @@ export function ExerciseSetupScreen({
 
     setSavingAll(true);
     try {
-      await runJournal(plan, routineId, exIdMap);
+      await runJournal(plan, routineId, exIdMap, weightUnit);
       journalRef.current = makeJournal();
       await reloadFromDb();
       toast.success("All changes saved!");
@@ -908,6 +1002,7 @@ export function ExerciseSetupScreen({
               name={ex.name}
               initials={initials}
               items={items}
+              weightUnitLabel={weightUnitLabel}
               mode={inWorkout ? "workout" : "edit"}
               onChange={(key, field, value) =>
                 onChangeSet(

--- a/components/sets/ExerciseSetEditorCard.tsx
+++ b/components/sets/ExerciseSetEditorCard.tsx
@@ -8,6 +8,7 @@ type Props = {
   name: string;
   initials: string;
   items: SetListItem[];
+  weightUnitLabel?: string;
 
   onChange?: (key: string | number, field: "reps" | "weight", value: string) => void;
   onRemove?: (key: string | number) => void;
@@ -37,6 +38,7 @@ type Props = {
 
 const ExerciseSetEditorCard: React.FC<Props> = ({
   items,
+  weightUnitLabel,
   onChange,
   onRemove,
   onAdd,
@@ -66,6 +68,7 @@ const ExerciseSetEditorCard: React.FC<Props> = ({
       <SetList
         mode={mode}
         items={items}
+        weightUnitLabel={weightUnitLabel}
         onDeleteExercise={mode === "workout" ? undefined : onDeleteExercise}
         deleteDisabled={deleteDisabled}
         onChange={onChange}

--- a/components/sets/SetList.tsx
+++ b/components/sets/SetList.tsx
@@ -20,6 +20,9 @@ export interface SetListProps {
   mode?: SetListMode;
   items: SetListItem[];
 
+  /** Weight unit label shown in the header */
+  weightUnitLabel?: string;
+
   /** Used when interactive */
   onChange?: (key: string | number, field: "reps" | "weight", value: string) => void;
   onRemove?: (key: string | number) => void;
@@ -43,6 +46,7 @@ export interface SetListProps {
 const SetList: React.FC<SetListProps> = ({
   mode = "edit",
   items,
+  weightUnitLabel = "kg",
   onChange,
   onRemove,
   onAdd,
@@ -92,7 +96,7 @@ const SetList: React.FC<SetListProps> = ({
       /* RAVI DBG: style={{ border: "2px solid green" }}*/>
         <span>Set</span>
         <span className="text-center">Reps</span>
-        <span className="text-center">Weight (kg)</span>
+        <span className="text-center">Weight ({weightUnitLabel})</span>
         <span />
       </div>
 

--- a/utils/unitConversion.ts
+++ b/utils/unitConversion.ts
@@ -1,0 +1,102 @@
+import type { UnitLength, UnitWeight } from "./supabase/supabase-types";
+
+export const DEFAULT_LENGTH_UNIT: UnitLength = "cm";
+export const DEFAULT_WEIGHT_UNIT: UnitWeight = "kg";
+
+const CM_PER_METER = 100;
+const LB_PER_KG = 2.2046226218;
+
+const roundTo = (value: number, precision: number): number => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+export const formatNumber = (value: number, precision: number): string => {
+  if (!Number.isFinite(value)) {
+    return "";
+  }
+  if (precision <= 0) {
+    return Math.round(value).toString();
+  }
+  const rounded = roundTo(value, precision);
+  return Number(rounded.toFixed(precision)).toString();
+};
+
+export const normalizeLengthUnit = (value: UnitLength | string | null | undefined): UnitLength => {
+  return value === "m" || value === "cm" ? (value as UnitLength) : DEFAULT_LENGTH_UNIT;
+};
+
+export const normalizeWeightUnit = (value: UnitWeight | string | null | undefined): UnitWeight => {
+  if (value === "lb" || value === "lbs") return "lb";
+  return DEFAULT_WEIGHT_UNIT;
+};
+
+export const lengthCmToUnit = (lengthCm: number, unit: UnitLength): number => {
+  const normalized = normalizeLengthUnit(unit);
+  return normalized === "m" ? lengthCm / CM_PER_METER : lengthCm;
+};
+
+export const lengthUnitToCm = (length: number, unit: UnitLength): number => {
+  const normalized = normalizeLengthUnit(unit);
+  return normalized === "m" ? length * CM_PER_METER : length;
+};
+
+export const weightKgToUnit = (weightKg: number, unit: UnitWeight): number => {
+  const normalized = normalizeWeightUnit(unit);
+  return normalized === "lb" ? weightKg * LB_PER_KG : weightKg;
+};
+
+export const weightUnitToKg = (weight: number, unit: UnitWeight): number => {
+  const normalized = normalizeWeightUnit(unit);
+  return normalized === "lb" ? weight / LB_PER_KG : weight;
+};
+
+export const formatLength = (
+  lengthCm: number | null | undefined,
+  unit: UnitLength,
+  precision = unit === "m" ? 2 : 1,
+): string => {
+  if (lengthCm == null || !Number.isFinite(lengthCm)) {
+    return "";
+  }
+  const converted = lengthCmToUnit(lengthCm, unit);
+  return formatNumber(converted, precision);
+};
+
+export const formatWeight = (
+  weightKg: number | null | undefined,
+  unit: UnitWeight,
+  precision = 1,
+): string => {
+  if (weightKg == null || !Number.isFinite(weightKg)) {
+    return "";
+  }
+  const converted = weightKgToUnit(weightKg, unit);
+  return formatNumber(converted, precision);
+};
+
+export const parseLengthInput = (value: string, unit: UnitLength): number | undefined => {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const numeric = Number(trimmed);
+  if (!Number.isFinite(numeric)) return undefined;
+  return lengthUnitToCm(numeric, unit);
+};
+
+export const parseWeightInput = (value: string, unit: UnitWeight): number | undefined => {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const numeric = Number(trimmed);
+  if (!Number.isFinite(numeric)) return undefined;
+  return weightUnitToKg(numeric, unit);
+};
+
+export const getLengthUnitLabel = (unit: UnitLength): string => {
+  const normalized = normalizeLengthUnit(unit);
+  return normalized;
+};
+
+export const getWeightUnitLabel = (unit: UnitWeight): string => {
+  const normalized = normalizeWeightUnit(unit);
+  return normalized === "lb" ? "lbs" : "kg";
+};


### PR DESCRIPTION
## Summary
- add a shared unitConversion utility to normalize units and format/parse height and weight values
- update profile, measurement, and workout screens to display inputs in the user’s preferred units while storing values in cm/kg
- adjust set list headers and journal persistence so workout weights are converted back to kilograms before saving

## Testing
- npm test -- --runTestsByPath test/journalRunner.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cebf5ec604832195d8b68c7da28dd0