### PR TITLE
Refactor progress screen data and utilities

### DIFF
--- a/components/screens/progress/MockData.ts
+++ b/components/screens/progress/MockData.ts
@@ -1,0 +1,167 @@
+import type { TimeRange } from "../../../src/types/progress";
+import type { ProgressDomain, SnapshotLookup } from "./types";
+import { daysAgoISO, generateTrend } from "./utils";
+
+export const MOCK_SNAPSHOTS: SnapshotLookup = {
+  strength: {
+    week: {
+      series: [
+        generateTrend("strength", "week", 1050, 0.32, 0),
+        generateTrend("strength", "week", 860, 0.28, 1),
+        generateTrend("strength", "week", 1340, 0.3, 2),
+        generateTrend("strength", "week", 620, 0.26, 3),
+      ],
+      kpis: [
+        { title: "Duration", unit: "hours", value: "3h 18m", currentNumeric: 198, previous: 172 },
+        { title: "Workouts", value: "5", currentNumeric: 5, previous: 4 },
+        { title: "Total Weight", unit: "kg", value: "82,640", currentNumeric: 82640, previous: 79320 },
+        { title: "Streak", unit: "days", value: "6", currentNumeric: 6, previous: 4 },
+      ],
+      history: [
+        { type: "strength", id: "s1", name: "Upper Power", date: daysAgoISO(1), duration: "52 min", totalWeight: "28,450 kg" },
+        { type: "strength", id: "s2", name: "Posterior Chain", date: daysAgoISO(3), duration: "47 min", totalWeight: "30,120 kg" },
+        { type: "strength", id: "s3", name: "Power Pull", date: daysAgoISO(5), duration: "41 min", totalWeight: "24,360 kg" },
+      ],
+    },
+    threeMonths: {
+      series: [
+        generateTrend("strength", "threeMonths", 1220, 0.24, 0),
+        generateTrend("strength", "threeMonths", 940, 0.22, 1),
+        generateTrend("strength", "threeMonths", 1480, 0.25, 2),
+        generateTrend("strength", "threeMonths", 680, 0.21, 3),
+      ],
+      kpis: [
+        { title: "Duration", unit: "hours", value: "12h 42m", currentNumeric: 762, previous: 708 },
+        { title: "Workouts", value: "18", currentNumeric: 18, previous: 16 },
+        { title: "Total Weight", unit: "kg", value: "322,130", currentNumeric: 322130, previous: 304980 },
+        { title: "Streak", unit: "days", value: "12", currentNumeric: 12, previous: 9 },
+      ],
+      history: [],
+    },
+    sixMonths: {
+      series: [
+        generateTrend("strength", "sixMonths", 1380, 0.18, 0),
+        generateTrend("strength", "sixMonths", 980, 0.17, 1),
+        generateTrend("strength", "sixMonths", 1620, 0.2, 2),
+        generateTrend("strength", "sixMonths", 720, 0.15, 3),
+      ],
+      kpis: [
+        { title: "Duration", unit: "hours", value: "156", currentNumeric: 9360, previous: 9020 },
+        { title: "Workouts", value: "182", currentNumeric: 182, previous: 178 },
+        { title: "Total Weight", unit: "kg", value: "3.4M", currentNumeric: 3400000, previous: 3320000 },
+        { title: "Streak", unit: "days", value: "21", currentNumeric: 21, previous: 18 },
+      ],
+      history: [],
+    },
+  },
+  cardio: {
+    week: {
+      series: [
+        generateTrend("cardio", "week", 8, 0.32, 0),
+        generateTrend("cardio", "week", 6.4, 0.28, 1),
+        generateTrend("cardio", "week", 9.8, 0.3, 2),
+        generateTrend("cardio", "week", 5.2, 0.26, 3),
+      ],
+      kpis: [
+        { title: "Total Time", unit: "hours", value: "4h 05m", currentNumeric: 245, previous: 203 },
+        { title: "Distance", unit: "km", value: "42.5", currentNumeric: 42.5, previous: 38.2 },
+        { title: "Calories", unit: "kcal", value: "3,420", currentNumeric: 3420, previous: 3150 },
+        { title: "Steps", value: "64,210", currentNumeric: 64210, previous: 60890 },
+      ],
+      history: [
+        { type: "cardio", id: "c1", activity: "Outdoor Run", date: daysAgoISO(1), duration: "00:42:10", distance: "7.4 km", calories: "612 kcal" },
+        { type: "cardio", id: "c2", activity: "Indoor Run", date: daysAgoISO(3), duration: "00:35:05", distance: "5.6 km", calories: "438 kcal" },
+        { type: "cardio", id: "c3", activity: "Cycling", date: daysAgoISO(5), duration: "00:48:44", distance: "18.2 km", calories: "502 kcal" },
+      ],
+    },
+    threeMonths: {
+      series: [
+        generateTrend("cardio", "threeMonths", 28, 0.22, 0),
+        generateTrend("cardio", "threeMonths", 21, 0.2, 1),
+        generateTrend("cardio", "threeMonths", 34, 0.23, 2),
+        generateTrend("cardio", "threeMonths", 17, 0.19, 3),
+      ],
+      kpis: [
+        { title: "Total Time", unit: "hours", value: "15h 38m", currentNumeric: 938, previous: 902 },
+        { title: "Distance", unit: "km", value: "168", currentNumeric: 168, previous: 160 },
+        { title: "Calories", unit: "kcal", value: "13,420", currentNumeric: 13420, previous: 12680 },
+        { title: "Steps", value: "262,410", currentNumeric: 262410, previous: 254000 },
+      ],
+      history: [],
+    },
+    sixMonths: {
+      series: [
+        generateTrend("cardio", "sixMonths", 52, 0.18, 0),
+        generateTrend("cardio", "sixMonths", 38, 0.16, 1),
+        generateTrend("cardio", "sixMonths", 58, 0.19, 2),
+        generateTrend("cardio", "sixMonths", 32, 0.15, 3),
+      ],
+      kpis: [
+        { title: "Total Time", unit: "hours", value: "168", currentNumeric: 10080, previous: 9980 },
+        { title: "Distance", unit: "km", value: "1,932", currentNumeric: 1932, previous: 1870 },
+        { title: "Calories", unit: "kcal", value: "124,650", currentNumeric: 124650, previous: 123200 },
+        { title: "Steps", value: "2.9M", currentNumeric: 2900000, previous: 2840000 },
+      ],
+      history: [],
+    },
+  },
+  measurement: {
+    week: {
+      series: [
+        generateTrend("measurement", "week", 101.2, 0.03, 0),
+        generateTrend("measurement", "week", 36.4, 0.025, 1),
+        generateTrend("measurement", "week", 58.8, 0.024, 2),
+        generateTrend("measurement", "week", 96.7, 0.028, 3),
+      ],
+      kpis: [
+        { title: "Chest", unit: "cm", value: "101.2", currentNumeric: 101.2, previous: 101.5 },
+        { title: "Arms", unit: "cm", value: "36.4", currentNumeric: 36.4, previous: 36.1 },
+        { title: "Legs", unit: "cm", value: "58.8", currentNumeric: 58.8, previous: 58.6 },
+        { title: "Back", unit: "cm", value: "96.7", currentNumeric: 96.7, previous: 97.1 },
+      ],
+      history: [],
+    },
+    threeMonths: {
+      series: [
+        generateTrend("measurement", "threeMonths", 101.4, 0.03, 0),
+        generateTrend("measurement", "threeMonths", 36.2, 0.024, 1),
+        generateTrend("measurement", "threeMonths", 59.1, 0.022, 2),
+        generateTrend("measurement", "threeMonths", 96.9, 0.027, 3),
+      ],
+      kpis: [
+        { title: "Chest", unit: "cm", value: "101.4", currentNumeric: 101.4, previous: 102.0 },
+        { title: "Arms", unit: "cm", value: "36.2", currentNumeric: 36.2, previous: 36.0 },
+        { title: "Legs", unit: "cm", value: "59.1", currentNumeric: 59.1, previous: 58.9 },
+        { title: "Back", unit: "cm", value: "96.9", currentNumeric: 96.9, previous: 97.3 },
+      ],
+      history: [],
+    },
+    sixMonths: {
+      series: [
+        generateTrend("measurement", "sixMonths", 102.8, 0.032, 0),
+        generateTrend("measurement", "sixMonths", 36.0, 0.022, 1),
+        generateTrend("measurement", "sixMonths", 59.6, 0.02, 2),
+        generateTrend("measurement", "sixMonths", 97.2, 0.026, 3),
+      ],
+      kpis: [
+        { title: "Chest", unit: "cm", value: "102.8", currentNumeric: 102.8, previous: 103.6 },
+        { title: "Arms", unit: "cm", value: "36.0", currentNumeric: 36.0, previous: 35.8 },
+        { title: "Legs", unit: "cm", value: "59.6", currentNumeric: 59.6, previous: 59.2 },
+        { title: "Back", unit: "cm", value: "97.2", currentNumeric: 97.2, previous: 97.9 },
+      ],
+      history: [],
+    },
+  },
+};
+
+export const DOMAIN_OPTIONS: Array<{ value: ProgressDomain; label: string }> = [
+  { value: "strength", label: "Strength" },
+  { value: "cardio", label: "Cardio" },
+  { value: "measurement", label: "Measurement" },
+];
+
+export const RANGE_OPTIONS: Array<{ value: TimeRange; label: string }> = [
+  { value: "week", label: "Week" },
+  { value: "threeMonths", label: "3 Month" },
+  { value: "sixMonths", label: "6 Month" },
+];

--- a/components/screens/progress/types.ts
+++ b/components/screens/progress/types.ts
@@ -1,0 +1,48 @@
+import type { TimeRange } from "../../../src/types/progress";
+
+export type TrendPoint = {
+  x: string;
+  y: number;
+  isPersonalBest?: boolean;
+};
+
+export type ProgressDomain = "strength" | "cardio" | "measurement";
+
+export type KpiDatum = {
+  title: string;
+  value: string;
+  unit?: string;
+  previous?: number;
+  currentNumeric?: number;
+};
+
+export type StrengthHistoryEntry = {
+  type: "strength";
+  id: string;
+  name: string;
+  date: string;
+  duration: string;
+  totalWeight: string;
+  routineTemplateId?: number;
+};
+
+export type CardioHistoryEntry = {
+  type: "cardio";
+  id: string;
+  activity: string;
+  date: string;
+  duration: string;
+  distance: string;
+  calories?: string;
+  routineTemplateId?: number;
+};
+
+export type HistoryEntry = StrengthHistoryEntry | CardioHistoryEntry;
+
+export type Snapshot = {
+  series: TrendPoint[][];
+  kpis: KpiDatum[];
+  history: HistoryEntry[];
+};
+
+export type SnapshotLookup = Record<ProgressDomain, Record<TimeRange, Snapshot>>;

--- a/components/screens/progress/utils.ts
+++ b/components/screens/progress/utils.ts
@@ -1,0 +1,329 @@
+import type { TimeRange } from "../../../src/types/progress";
+import type { LoadedExercise } from "../../../utils/routineLoader";
+import type { ProgressDomain, TrendPoint } from "./types";
+
+export const RANGE_POINTS: Record<TimeRange, number> = { week: 7, threeMonths: 12, sixMonths: 6 };
+export const RANGE_STEPS: Record<TimeRange, number> = { week: 1, threeMonths: 7, sixMonths: 30 };
+
+const TREND_ICONS = {
+  up: "▲",
+  down: "▼",
+  flat: "=",
+} as const;
+
+const integerFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+const decimalOneFormatter = new Intl.NumberFormat(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+const decimalTwoFormatter = new Intl.NumberFormat(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+export function normalizeActivity(activity: string) {
+  const mapping: Record<string, string> = {
+    "outdoor walk": "Outdoor Walk",
+    "indoor walk": "Indoor Walk",
+    "outdoor run": "Outdoor Run",
+    "indoor run": "Indoor Run",
+    cycling: "Cycling",
+    elliptical: "Elliptical",
+    rowing: "Rowing",
+    "stair stepper": "Stair Stepper",
+    swimming: "Swimming",
+  };
+  return mapping[activity.trim().toLowerCase()] ?? activity;
+}
+
+export function daysAgoISO(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString();
+}
+
+export function formatHistoryDate(iso: string) {
+  const date = new Date(iso);
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function estimateRoutineDurationMinutes(exerciseCount: number) {
+  if (!Number.isFinite(exerciseCount) || exerciseCount <= 0) return 30;
+  return exerciseCount * 10;
+}
+
+export function calculateTotalWeight(exercises: LoadedExercise[]) {
+  return exercises.reduce((total, exercise) => {
+    return (
+      total +
+      exercise.sets.reduce((setTotal, set) => {
+        const reps = Number.parseFloat(set.reps);
+        const weight = Number.parseFloat(set.weight);
+        if (!Number.isFinite(reps) || !Number.isFinite(weight)) return setTotal;
+        if (reps <= 0 || weight <= 0) return setTotal;
+        return setTotal + reps * weight;
+      }, 0)
+    );
+  }, 0);
+}
+
+export function formatDuration(minutes: number) {
+  const safeMinutes = Number.isFinite(minutes) && minutes > 0 ? Math.round(minutes) : 0;
+  const hours = Math.floor(safeMinutes / 60);
+  const remainingMinutes = safeMinutes % 60;
+  if (hours > 0) {
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  }
+  return `${Math.max(remainingMinutes, 1)} min`;
+}
+
+export function formatWeight(weightKg: number) {
+  const safeWeight = Number.isFinite(weightKg) && weightKg > 0 ? weightKg : 0;
+  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(Math.round(safeWeight))} kg`;
+}
+
+export function generateTrend(
+  domain: ProgressDomain,
+  range: TimeRange,
+  seed: number,
+  variance: number,
+  metric: number,
+): TrendPoint[] {
+  const today = new Date();
+  const points = RANGE_POINTS[range];
+  const stepDays = RANGE_STEPS[range];
+  const rng = createRng(`${domain}-${range}-${seed}-${variance}-${metric}`);
+
+  let current = domain === "measurement" ? seed : seed * 0.55;
+  if (domain === "strength") {
+    current *= 1 + metric * 0.08;
+  } else if (domain === "cardio") {
+    current *= 1 + metric * 0.05;
+  } else {
+    current *= 1 + metric * 0.02;
+  }
+  const values: TrendPoint[] = [];
+
+  for (let index = 0; index < points; index += 1) {
+    const date = new Date(today);
+    date.setDate(today.getDate() - (points - 1 - index) * stepDays);
+    const progress = points > 1 ? index / (points - 1) : 1;
+
+    const noise = (rng() - 0.5) * variance * seed * 0.18;
+
+    if (domain === "strength") {
+      const push = seed * variance * (0.12 + rng() * 0.18 + metric * 0.04);
+      const plateauChance = rng();
+      if (plateauChance > 0.75) {
+        current += push * 0.15 + noise;
+      } else {
+        current += push + noise;
+      }
+    } else if (domain === "cardio") {
+      const burst = seed * variance * (0.08 + rng() * 0.22 + metric * 0.03);
+      current += burst + noise;
+      if (rng() > 0.82) {
+        current -= seed * variance * 0.12;
+      }
+    } else {
+      const downwardDrift = seed * variance * (0.04 + progress * 0.06 + metric * 0.015);
+      current -= downwardDrift;
+      current += noise;
+    }
+
+    const baseFloor = domain === "measurement" ? seed * 0.75 : seed * 0.35;
+    const baseCeiling = domain === "measurement" ? seed * 1.05 : seed * (range === "sixMonths" ? 1.45 : 1.25);
+    const floor = domain === "measurement" ? baseFloor * (1 - metric * 0.02) : baseFloor * (1 + metric * 0.03);
+    const ceiling = baseCeiling * (1 + metric * 0.08);
+    current = Math.min(ceiling, Math.max(floor, current));
+
+    values.push({
+      x: date.toISOString(),
+      y: Number(current.toFixed(2)),
+      isPersonalBest: index === points - 2,
+    });
+  }
+
+  return values;
+}
+
+export function formatDayLabel(range: TimeRange, iso: string, index: number, total: number) {
+  const date = new Date(iso);
+  if (range === "week") {
+    return date.toLocaleDateString(undefined, { weekday: "short" });
+  }
+
+  if (range === "threeMonths") {
+    const month = date.toLocaleDateString(undefined, { month: "short" });
+    const weekInMonth = getWeekOfMonth(date);
+    return `${month} W${weekInMonth}`;
+  }
+
+  return date.toLocaleDateString(undefined, { month: "short" });
+}
+
+export function formatTickValue(value: number) {
+  if (Math.abs(value) >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}k`;
+  }
+  return value.toFixed(0);
+}
+
+export function generateTicks(domain: [number, number], count: number) {
+  const [min, max] = domain;
+  if (min === max) {
+    return [Number(min.toFixed(2))];
+  }
+  const step = (max - min) / Math.max(count - 1, 1);
+  return Array.from({ length: count }, (_, index) => Number((min + index * step).toFixed(2)));
+}
+
+export function getKpiFormatter(domain: ProgressDomain, index: number): (value: number) => string {
+  switch (domain) {
+    case "strength":
+      return [
+        formatDurationMinutes,
+        formatWorkouts,
+        formatKilograms,
+        formatDays,
+      ][index] ?? ((value) => integerFormatter.format(Math.round(value)));
+    case "cardio":
+      return [
+        formatDurationMinutes,
+        formatKilometers,
+        formatCalories,
+        formatSteps,
+      ][index] ?? ((value) => integerFormatter.format(Math.round(value)));
+    case "measurement":
+    default:
+      return [formatCentimeters, formatCentimeters, formatCentimeters, formatCentimeters][index] ??
+        ((value) => decimalTwoFormatter.format(clampNonNegative(value)));
+  }
+}
+
+export function determineTrend(currentValue: number | null, previousValue: number | null) {
+  if (currentValue === null || previousValue === null) {
+    return {
+      icon: TREND_ICONS.flat,
+      color: "text-[rgba(34,49,63,0.55)]",
+      colorActive: "text-[#22313F]",
+      text: "No change",
+      delta: 0,
+    } as const;
+  }
+  const current = clampNonNegative(currentValue);
+  const previous = clampNonNegative(previousValue);
+  const difference = current - previous;
+  if (Math.abs(difference) < 0.01) {
+    return {
+      icon: TREND_ICONS.flat,
+      color: "text-[rgba(34,49,63,0.45)]",
+      colorActive: "text-[#22313F]",
+      text: "Same as prior",
+      delta: 0,
+    } as const;
+  }
+  if (difference > 0) {
+    return {
+      icon: TREND_ICONS.up,
+      color: "text-[rgba(46,125,102,0.85)]",
+      colorActive: "text-[rgba(46,125,102,1)]",
+      text: "Up",
+      delta: difference,
+    } as const;
+  }
+  return {
+    icon: TREND_ICONS.down,
+    color: "text-[rgba(226,125,96,0.85)]",
+    colorActive: "text-[rgba(226,125,96,1)]",
+    text: "Down",
+    delta: Math.abs(difference),
+  } as const;
+}
+
+export function getEncouragement(firstName?: string | null) {
+  const suffix = firstName ? `, ${firstName}` : "";
+  return `You’ve got this${suffix}`;
+}
+
+export function extractFirstName(profile: { first_name?: string | null; display_name?: string | null } | null): string | null {
+  if (!profile) return null;
+  const direct = profile.first_name?.trim();
+  if (direct) {
+    return direct.split(/\s+/)[0];
+  }
+  const display = profile.display_name?.trim();
+  if (display) {
+    const [first] = display.split(/\s+/);
+    if (first) {
+      return first;
+    }
+  }
+  return null;
+}
+
+export function createRng(key: string) {
+  let seed = 0;
+  for (let index = 0; index < key.length; index += 1) {
+    seed = (seed << 5) - seed + key.charCodeAt(index);
+    seed |= 0;
+  }
+  return mulberry32(seed >>> 0);
+}
+
+function mulberry32(a: number) {
+  return function rng() {
+    a += 0x6d2b79f5;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = t + Math.imul(t ^ (t >>> 7), 61 | t) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function formatDurationMinutes(value: number) {
+  const totalMinutes = clampNonNegative(value);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = Math.round(totalMinutes % 60);
+  if (hours > 0 && minutes > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
+function formatKilograms(value: number) {
+  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} kg`;
+}
+
+function formatDays(value: number) {
+  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} days`;
+}
+
+function formatWorkouts(value: number) {
+  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} workouts`;
+}
+
+function formatKilometers(value: number) {
+  return `${decimalOneFormatter.format(clampNonNegative(value))} km`;
+}
+
+function formatCalories(value: number) {
+  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} kcal`;
+}
+
+function formatSteps(value: number) {
+  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} steps`;
+}
+
+function formatCentimeters(value: number) {
+  return `${decimalTwoFormatter.format(clampNonNegative(value))} cm`;
+}
+
+function clampNonNegative(value: number) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function getWeekOfMonth(date: Date) {
+  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+  const offset = firstDay.getDay() === 0 ? 6 : firstDay.getDay() - 1;
+  return Math.floor((date.getDate() + offset - 1) / 7) + 1;
+}


### PR DESCRIPTION
## Summary
- extract progress mock snapshots and shared types into components/screens/progress
- move utility helpers for metrics, history, and charting into a dedicated module and reuse them inside ProgressScreen
- centralize frequently reused color tokens and update the progress UI to consume the new modules

## Testing
- npm run test -- --watchAll=false *(fails: existing Jest configuration cannot parse import.meta in supabase-db-write.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a67f5504832190d8e43ed1509859