### PR TITLE
Remove strength progress domain and mix workouts history

### DIFF
--- a/components/progress/Progress.types.ts
+++ b/components/progress/Progress.types.ts
@@ -6,7 +6,7 @@ export type TrendPoint = {
   isPersonalBest?: boolean;
 };
 
-export type ProgressDomain = "strength" | "cardio" | "measurement";
+export type ProgressDomain = "cardio" | "measurement";
 
 export type KpiDatum = {
   title: string;

--- a/components/screens/ProgressScreen.tsx
+++ b/components/screens/ProgressScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import AppScreen from "../layouts/AppScreen";
 import type { TimeRange } from "../../src/types/progress";
-import type { HistoryEntry, ProgressDomain } from "../progress/Progress.types";
+import type { ProgressDomain } from "../progress/Progress.types";
 import { PROGRESS_MOCK_SNAPSHOTS } from "./progress/MockData";
 import { TrendOverview } from "./progress/TrendOverview";
 import { KPI_COLORS, getEncouragement, getKpiFormatter } from "./progress/util";
@@ -18,7 +18,7 @@ import Spacer from "../layouts/Spacer";
 import { DomainSelector } from "./progress/DomainSelector";
 import { RangeSelector } from "./progress/RangeSelector";
 import { DOMAIN_LABELS, DOMAIN_OPTIONS, RANGE_LABELS, RANGE_OPTIONS } from "./progress/constants";
-import { useCardioProgressSnapshot, useStrengthHistory, useUserFirstName } from "./progress/hooks";
+import { useCardioProgressSnapshot, useUserFirstName } from "./progress/hooks";
 
 const USE_CARDIO_WEEK_MOCK = true;
 
@@ -33,7 +33,6 @@ export function ProgressScreen({ bottomBar, onSelectRoutine }: ProgressScreenPro
   const [selectedKpiIndex, setSelectedKpiIndex] = useState(0);
   const { userToken } = useAuth();
   const firstName = useUserFirstName(userToken);
-  const { history: strengthHistory, loading: strengthHistoryLoading } = useStrengthHistory(userToken);
   const {
     snapshot: fetchedCardioSnapshot,
     loading: fetchedCardioLoading,
@@ -50,18 +49,12 @@ export function ProgressScreen({ bottomBar, onSelectRoutine }: ProgressScreenPro
 
   const cardioLoading = isUsingCardioMockData ? false : fetchedCardioLoading;
 
-  const baseSnapshot = useMemo(() => {
+  const snapshot = useMemo(() => {
     if (domain === "cardio" && cardioSnapshot) {
       return cardioSnapshot;
     }
     return PROGRESS_MOCK_SNAPSHOTS[domain][range];
   }, [cardioSnapshot, domain, range]);
-  const snapshot = useMemo(() => {
-    if (domain === "strength" && strengthHistory.length > 0) {
-      return { ...baseSnapshot, history: strengthHistory };
-    }
-    return baseSnapshot;
-  }, [baseSnapshot, domain, strengthHistory]);
   const valueFormatter = useMemo(() => getKpiFormatter(domain, selectedKpiIndex), [domain, selectedKpiIndex]);
   const trendSeries = snapshot.series[selectedKpiIndex] ?? snapshot.series[0] ?? [];
   const shouldShowCardioWeekHistory = domain === "cardio" && range === "week";
@@ -75,12 +68,8 @@ export function ProgressScreen({ bottomBar, onSelectRoutine }: ProgressScreenPro
   const shouldShowHistory =
     !shouldShowCardioWeekHistory &&
     domain !== "measurement" &&
-    (snapshot.history.length > 0 ||
-      (domain === "strength" && strengthHistoryLoading) ||
-      (domain === "cardio" && cardioLoading));
-  const showHistoryLoading =
-    (domain === "strength" && strengthHistoryLoading && snapshot.history.length === 0) ||
-    (domain === "cardio" && cardioLoading && snapshot.history.length === 0);
+    (snapshot.history.length > 0 || (domain === "cardio" && cardioLoading));
+  const showHistoryLoading = domain === "cardio" && cardioLoading && snapshot.history.length === 0;
 
   useEffect(() => {
     setSelectedKpiIndex(0);
@@ -124,14 +113,6 @@ export function ProgressScreen({ bottomBar, onSelectRoutine }: ProgressScreenPro
   const rangeLabel = RANGE_LABELS[range] ?? "";
   const trendTitle = snapshot.kpis[selectedKpiIndex]?.title ?? snapshot.kpis[0]?.title ?? "";
 
-  const handleStrengthHistorySelect = (entry: HistoryEntry) => {
-    if (entry.type !== "strength") return;
-    if (!onSelectRoutine) return;
-    const { routineTemplateId } = entry;
-    if (typeof routineTemplateId !== "number") return;
-    onSelectRoutine(routineTemplateId, entry.name, RoutineAccess.ReadOnly);
-  };
-
   return (
     <AppScreen
       header={null}
@@ -161,11 +142,7 @@ export function ProgressScreen({ bottomBar, onSelectRoutine }: ProgressScreenPro
         {shouldShowCardioWeekHistory ? (
           <CardioWeekHistory days={cardioWeekHistoryDays} />
         ) : shouldShowHistory ? (
-          <HistorySection
-            entries={snapshot.history}
-            showLoading={showHistoryLoading}
-            onSelectStrength={domain === "strength" ? handleStrengthHistorySelect : undefined}
-          />
+          <HistorySection entries={snapshot.history} showLoading={showHistoryLoading} />
         ) : null}
       </Stack>
     </AppScreen>

--- a/components/screens/progress/HistorySection.tsx
+++ b/components/screens/progress/HistorySection.tsx
@@ -10,7 +10,6 @@ import { PROGRESS_THEME, formatHistoryDate, normalizeActivity } from "./util";
 type HistorySectionProps = {
   entries: HistoryEntry[];
   showLoading: boolean;
-  onSelectStrength?: (entry: StrengthHistoryEntry) => void;
 };
 
 const HISTORY_SECTION_STYLE: CSSProperties = {
@@ -18,16 +17,11 @@ const HISTORY_SECTION_STYLE: CSSProperties = {
   boxShadow: PROGRESS_THEME.cardShadow,
 };
 
-const HISTORY_ITEM_BUTTON_STYLE: CSSProperties & { ["--tw-ring-color"]?: string } = {
-  backgroundColor: PROGRESS_THEME.historyBackground,
-  ["--tw-ring-color"]: PROGRESS_THEME.accentPrimaryFocusRing,
-};
-
 const HISTORY_ITEM_STYLE: CSSProperties = {
   backgroundColor: PROGRESS_THEME.historyBackground,
 };
 
-function HistorySection({ entries, showLoading, onSelectStrength }: HistorySectionProps) {
+function HistorySection({ entries, showLoading }: HistorySectionProps) {
   return (
     <section className="rounded-3xl border bg-white p-5" style={HISTORY_SECTION_STYLE}>
       <div className="flex items-center justify-between">
@@ -45,19 +39,15 @@ function HistorySection({ entries, showLoading, onSelectStrength }: HistorySecti
           {[...entries]
             .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
             .map((entry) => {
-              if (entry.type === "strength") {
-                return (
-                  <li key={entry.id}>{renderStrengthEntry(entry, onSelectStrength)}</li>
-                );
-              }
-
               return (
                 <li
                   key={entry.id}
                   className="flex items-center justify-between rounded-2xl px-4 py-3"
                   style={HISTORY_ITEM_STYLE}
                 >
-                  {renderCardioEntry(entry)}
+                  {entry.type === "strength"
+                    ? renderStrengthEntry(entry)
+                    : renderCardioEntry(entry)}
                 </li>
               );
             })}
@@ -67,8 +57,8 @@ function HistorySection({ entries, showLoading, onSelectStrength }: HistorySecti
   );
 }
 
-function renderStrengthEntry(entry: StrengthHistoryEntry, onSelectStrength?: (entry: StrengthHistoryEntry) => void) {
-  const content = (
+function renderStrengthEntry(entry: StrengthHistoryEntry) {
+  return (
     <>
       <div>
         <p className="text-sm font-semibold text-[#111111]">{entry.name}</p>
@@ -78,27 +68,6 @@ function renderStrengthEntry(entry: StrengthHistoryEntry, onSelectStrength?: (en
       </div>
       <p className="text-sm font-semibold text-[#111111]">{entry.totalWeight}</p>
     </>
-  );
-
-  const canNavigate = typeof entry.routineTemplateId === "number" && Boolean(onSelectStrength);
-
-  if (!canNavigate) {
-    return (
-      <div className="flex items-center justify-between rounded-2xl px-4 py-3" style={HISTORY_ITEM_STYLE}>
-        {content}
-      </div>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={() => onSelectStrength?.(entry)}
-      className="flex w-full items-center justify-between rounded-2xl px-4 py-3 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-      style={HISTORY_ITEM_BUTTON_STYLE}
-    >
-      {content}
-    </button>
   );
 }
 

--- a/components/screens/progress/MockData.ts
+++ b/components/screens/progress/MockData.ts
@@ -5,57 +5,6 @@ const RANGE_POINTS: Record<TimeRange, number> = { week: 7, threeMonths: 12, sixM
 const RANGE_STEPS: Record<TimeRange, number> = { week: 1, threeMonths: 7, sixMonths: 30 };
 
 const PROGRESS_MOCK_SNAPSHOTS: DomainSnapshotMap = {
-  strength: {
-    week: {
-      series: [
-        generateTrend("strength", "week", 1050, 0.32, 0),
-        generateTrend("strength", "week", 860, 0.28, 1),
-        generateTrend("strength", "week", 1340, 0.3, 2),
-        generateTrend("strength", "week", 620, 0.26, 3),
-      ],
-      kpis: [
-        { title: "Duration", unit: "hours", value: "3h 18m", currentNumeric: 198, previous: 172 },
-        { title: "Workouts", value: "5", currentNumeric: 5, previous: 4 },
-        { title: "Total Weight", unit: "kg", value: "82,640", currentNumeric: 82640, previous: 79320 },
-        { title: "Streak", unit: "days", value: "6", currentNumeric: 6, previous: 4 },
-      ],
-      history: [
-        { type: "strength", id: "s1", name: "Upper Power", date: daysAgoISO(1), duration: "52 min", totalWeight: "28,450 kg" },
-        { type: "strength", id: "s2", name: "Posterior Chain", date: daysAgoISO(3), duration: "47 min", totalWeight: "30,120 kg" },
-        { type: "strength", id: "s3", name: "Power Pull", date: daysAgoISO(5), duration: "41 min", totalWeight: "24,360 kg" },
-      ],
-    },
-    threeMonths: {
-      series: [
-        generateTrend("strength", "threeMonths", 1220, 0.24, 0),
-        generateTrend("strength", "threeMonths", 940, 0.22, 1),
-        generateTrend("strength", "threeMonths", 1480, 0.25, 2),
-        generateTrend("strength", "threeMonths", 680, 0.21, 3),
-      ],
-      kpis: [
-        { title: "Duration", unit: "hours", value: "12h 42m", currentNumeric: 762, previous: 708 },
-        { title: "Workouts", value: "18", currentNumeric: 18, previous: 16 },
-        { title: "Total Weight", unit: "kg", value: "322,130", currentNumeric: 322130, previous: 304980 },
-        { title: "Streak", unit: "days", value: "12", currentNumeric: 12, previous: 9 },
-      ],
-      history: [],
-    },
-    sixMonths: {
-      series: [
-        generateTrend("strength", "sixMonths", 1380, 0.18, 0),
-        generateTrend("strength", "sixMonths", 980, 0.17, 1),
-        generateTrend("strength", "sixMonths", 1620, 0.2, 2),
-        generateTrend("strength", "sixMonths", 720, 0.15, 3),
-      ],
-      kpis: [
-        { title: "Duration", unit: "hours", value: "156", currentNumeric: 9360, previous: 9020 },
-        { title: "Workouts", value: "182", currentNumeric: 182, previous: 178 },
-        { title: "Total Weight", unit: "kg", value: "3.4M", currentNumeric: 3400000, previous: 3320000 },
-        { title: "Streak", unit: "days", value: "21", currentNumeric: 21, previous: 18 },
-      ],
-      history: [],
-    },
-  },
   cardio: {
     week: {
       series: [
@@ -71,6 +20,9 @@ const PROGRESS_MOCK_SNAPSHOTS: DomainSnapshotMap = {
         { title: "Steps", value: "64,210", currentNumeric: 64210, previous: 60890 },
       ],
       history: [
+        { type: "strength", id: "s1", name: "Upper Power", date: daysAgoISO(1), duration: "52 min", totalWeight: "28,450 kg" },
+        { type: "strength", id: "s2", name: "Posterior Chain", date: daysAgoISO(3), duration: "47 min", totalWeight: "30,120 kg" },
+        { type: "strength", id: "s3", name: "Power Pull", date: daysAgoISO(5), duration: "41 min", totalWeight: "24,360 kg" },
         {
           type: "cardio",
           id: "c1",
@@ -278,9 +230,7 @@ function generateTrend(domain: ProgressDomain, range: TimeRange, seed: number, v
   const rng = createRng(`${domain}-${range}-${seed}-${variance}-${metric}`);
 
   let current = domain === "measurement" ? seed : seed * 0.55;
-  if (domain === "strength") {
-    current *= 1 + metric * 0.08;
-  } else if (domain === "cardio") {
+  if (domain === "cardio") {
     current *= 1 + metric * 0.05;
   } else {
     current *= 1 + metric * 0.02;
@@ -294,15 +244,7 @@ function generateTrend(domain: ProgressDomain, range: TimeRange, seed: number, v
 
     const noise = (rng() - 0.5) * variance * seed * 0.18;
 
-    if (domain === "strength") {
-      const push = seed * variance * (0.12 + rng() * 0.18 + metric * 0.04);
-      const plateauChance = rng();
-      if (plateauChance > 0.75) {
-        current += push * 0.15 + noise;
-      } else {
-        current += push + noise;
-      }
-    } else if (domain === "cardio") {
+    if (domain === "cardio") {
       const burst = seed * variance * (0.08 + rng() * 0.22 + metric * 0.03);
       current += burst + noise;
       if (rng() > 0.82) {

--- a/components/screens/progress/constants.ts
+++ b/components/screens/progress/constants.ts
@@ -5,7 +5,6 @@ export type DomainOption = { value: ProgressDomain; label: string };
 export type RangeOption = { value: TimeRange; label: string };
 
 export const DOMAIN_OPTIONS: DomainOption[] = [
-  { value: "strength", label: "Strength" },
   { value: "cardio", label: "Cardio" },
   { value: "measurement", label: "Measurement" },
 ];
@@ -17,7 +16,6 @@ export const RANGE_OPTIONS: RangeOption[] = [
 ];
 
 export const DOMAIN_LABELS: Record<ProgressDomain, string> = {
-  strength: "Strength",
   cardio: "Cardio",
   measurement: "Measurement",
 };

--- a/components/screens/progress/hooks.ts
+++ b/components/screens/progress/hooks.ts
@@ -1,19 +1,11 @@
 import { useEffect, useState } from "react";
 
-import type {
-  TimeRange,
-  CardioFocus,
-  CardioProgressSnapshot,
-  SeriesPoint,
-  CardioKpi,
-  CardioWorkoutSummary,
-} from "@/types/progress";
+import type { TimeRange, CardioFocus, CardioProgressSnapshot } from "@/types/progress";
 import { CardioProgressProvider } from "@/screen/progress/CardioProgress";
 import type { HistoryEntry, Snapshot } from "../../progress/Progress.types";
-import { supabaseAPI, SAMPLE_ROUTINE_USER_ID } from "../../../utils/supabase/supabase-api";
-import { loadRoutineExercisesWithSets } from "../../../utils/routineLoader";
+import { supabaseAPI } from "../../../utils/supabase/supabase-api";
 import type { Profile } from "../../../utils/supabase/supabase-types";
-import { calculateTotalWeight, estimateRoutineDurationMinutes, extractFirstName, formatDuration, formatWeight } from "./util";
+import { extractFirstName } from "./util";
 import { logger } from "../../../utils/logging";
 
 export function useUserFirstName(userToken: string | null | undefined) {
@@ -47,64 +39,6 @@ export function useUserFirstName(userToken: string | null | undefined) {
   }, [userToken]);
 
   return firstName;
-}
-
-export function useStrengthHistory(userToken: string | null | undefined) {
-  const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-
-    (async () => {
-      try {
-        const routines = await supabaseAPI.getSampleRoutines();
-        const entries: HistoryEntry[] = [];
-
-        for (const routine of routines.slice(0, 5)) {
-          if (cancelled) break;
-          try {
-            const exercises = await loadRoutineExercisesWithSets(routine.routine_template_id, {
-              userIdOverride: SAMPLE_ROUTINE_USER_ID,
-            });
-            const durationMinutes = estimateRoutineDurationMinutes(exercises.length);
-            const totalWeightKg = calculateTotalWeight(exercises);
-            entries.push({
-              type: "strength",
-              id: String(routine.routine_template_id),
-              routineTemplateId: routine.routine_template_id,
-              name: routine.name,
-              date: routine.created_at ?? new Date().toISOString(),
-              duration: formatDuration(durationMinutes),
-              totalWeight: formatWeight(totalWeightKg),
-            });
-          } catch (error) {
-            // Ignore routines that fail to load
-          }
-        }
-
-        if (!cancelled) {
-          entries.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-          setHistory(entries);
-        }
-      } catch (error) {
-        if (!cancelled) {
-          setHistory([]);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [userToken]);
-
-  return { history, loading };
 }
 
 const CARDIO_FOCUS_ORDER: CardioFocus[] = ["activeMinutes", "distance", "calories", "steps"];

--- a/components/screens/progress/util.ts
+++ b/components/screens/progress/util.ts
@@ -61,18 +61,6 @@ function formatDurationMinutes(value: number) {
   return `${minutes}m`;
 }
 
-function formatKilograms(value: number) {
-  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} kg`;
-}
-
-function formatDays(value: number) {
-  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} days`;
-}
-
-function formatWorkouts(value: number) {
-  return `${integerFormatter.format(Math.round(clampNonNegative(value)))} workouts`;
-}
-
 function formatKilometers(value: number) {
   return `${decimalOneFormatter.format(clampNonNegative(value))} km`;
 }
@@ -207,13 +195,6 @@ function extractFirstName(profile: Profile | null): string | null {
 
 function getKpiFormatter(domain: ProgressDomain, index: number): (value: number) => string {
   switch (domain) {
-    case "strength":
-      return [
-        formatDurationMinutes,
-        formatWorkouts,
-        formatKilograms,
-        formatDays,
-      ][index] ?? ((value) => integerFormatter.format(Math.round(value)));
     case "cardio":
       return [
         formatDurationMinutes,


### PR DESCRIPTION
## Summary
- drop the strength progress domain so only cardio and measurement remain
- merge strength sample workouts into the cardio mock history and simplify the trend generator
- streamline history rendering and hooks by removing strength-specific logic

## Testing
- npm test -- --runTestsByPath

------
https://chatgpt.com/codex/tasks/task_e_68d55cee1b0c83218ee53929439ed240