### PR TITLE
Streamline CardioProgress workout ingestion

### DIFF
--- a/src/screen/progress/CardioProgress.ts
+++ b/src/screen/progress/CardioProgress.ts
@@ -10,6 +10,8 @@ import type {
 } from "../../types/progress";
 import { logger } from "../../../utils/logging";
 
+const LOG_PREFIX = "[cardioProgess]";
+
 const TARGET_MINUTES = 40;
 const ACTIVITY_LABELS: Record<string, string> = {
   "outdoor walk": "Outdoor Walk",
@@ -61,6 +63,79 @@ const calorieFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigit
 const stepFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
 
 const MIN_MS = 60_000;
+
+type DateInput = string | number | Date | undefined | null;
+
+function toUtcDate(date: Date): Date {
+  return new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds(),
+      date.getMilliseconds(),
+    ),
+  );
+}
+
+function toUtcISOString(date: Date): string {
+  return toUtcDate(date).toISOString();
+}
+
+function toLocalDateTime(value: DateInput): Date | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  const valueIsString = typeof value === "string";
+  const hasExplicitOffset = valueIsString && /([zZ]|[+-]\d{2}:?\d{2})$/.test(value);
+
+  if (valueIsString && !hasExplicitOffset) {
+    return new Date(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    );
+  }
+
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    date.getHours(),
+    date.getMinutes(),
+    date.getSeconds(),
+    date.getMilliseconds(),
+  );
+}
+
+function toLocalDate(value: DateInput): Date | undefined {
+  const date = toLocalDateTime(value);
+  if (!date) {
+    return undefined;
+  }
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 12, 0, 0, 0);
+}
+
+function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+const SERIES_FOCUSES: CardioFocus[] = ["activeMinutes", "distance", "calories", "steps"];
 
 function normalizeActivityName(activity: string | undefined): string {
   if (!activity) return "Workout";
@@ -144,66 +219,178 @@ function safeNumber(value: unknown): number {
   }
   if (typeof value === "string") {
     const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : 0;
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
   }
   return 0;
 }
 
-function minutesToDisplay(value: number) {
-  const totalMinutes = Math.max(0, value);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = Math.round(totalMinutes % 60);
-  if (hours > 0) {
-    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-  }
-  return `${minuteFormatter.format(minutes)}m`;
-}
-
-function kilometersToDisplay(value: number) { return `${kmFormatter.format(Math.max(0, value))} km`; }
-
-function caloriesToDisplay(value: number) { return `${calorieFormatter.format(Math.max(0, value))}`;}
-
+function minutesToDisplay(value: number) { return `${minuteFormatter.format(Math.max(0, value))}`; }
+function kilometersToDisplay(value: number) { return `${kmFormatter.format(Math.max(0, value))}`; }
+function caloriesToDisplay(value: number) { return `${calorieFormatter.format(Math.max(0, value))}`; }
 function stepsToDisplay(value: number) { return `${stepFormatter.format(Math.max(0, value))}`; }
 
-/**
- * The provider is the single entry point that the progress screen calls via
- * {@link useWorkoutsProgressSnapshot}.  Each public method (series/kpis…)
- * funnels into {@link CardioProgressProvider.ensure}, which caches the
- * aggregated buckets for the requested range.  `ensure` delegates to
- * `fetchAggregated`, which asks Capacitor for the active platform and then
- * populates the buckets with native readings by calling
- * {@link CardioProgressProvider.populateFromIos} or
- * {@link CardioProgressProvider.populateFromAndroid}.  Those helpers are where
- * we invoke the HealthKit (via `capacitor-health`) and Health Connect (via
- * `@kiwi-health/capacitor-health-connect`) bridges to pull workouts, samples,
- * and aggregate totals directly from the phone before shaping them into the UI
- * friendly structures.
- */
+function averageHeartRate(bucket: Bucket): number | undefined {
+  if (bucket.totals.heartRateCount <= 0) {
+    return undefined;
+  }
+  return bucket.totals.heartRateSum / bucket.totals.heartRateCount;
+}
+
+function collectWorkouts(data: AggregatedData): CardioWorkoutSummary[] {
+  return [...data.previous, ...data.current].flatMap((bucket) => bucket.workouts);
+}
+
+function groupWorkoutsByDate(workouts: CardioWorkoutSummary[]): Record<string, CardioWorkoutSummary[]> {
+  const grouped: Record<string, CardioWorkoutSummary[]> = {};
+  for (const workout of workouts) {
+    const end = toLocalDate(workout.end);
+    if (!end) {
+      continue;
+    }
+    const key = formatDateKey(end);
+    if (!grouped[key]) {
+      grouped[key] = [];
+    }
+    grouped[key].push(workout);
+  }
+
+  for (const key of Object.keys(grouped)) {
+    grouped[key].sort((a, b) => {
+      const aEnd = toLocalDateTime(a.end)?.getTime() ?? 0;
+      const bEnd = toLocalDateTime(b.end)?.getTime() ?? 0;
+      return bEnd - aEnd;
+    });
+  }
+
+  return grouped;
+}
+
+function seriesUnavailableFromBuckets(
+  focus: CardioFocus,
+  buckets: ReturnType<typeof buildBucketSets>,
+  options?: { compare?: boolean },
+): CardioSeriesResponse {
+  const includePrevious = options?.compare !== false;
+  const mapBucket = (bucket: Bucket): SeriesPoint => ({ iso: bucket.iso, value: 0 });
+  return {
+    focus,
+    current: buckets.current.map(mapBucket),
+    previous: includePrevious ? buckets.previous.map(mapBucket) : undefined,
+  };
+}
+
+function kpisUnavailable(): CardioKpi[] {
+  return [
+    {
+      key: "activeMinutes",
+      title: "Total Time",
+      unit: "minutes",
+      value: "N/A",
+    },
+    {
+      key: "distance",
+      title: "Distance",
+      unit: "km",
+      value: "N/A",
+    },
+    {
+      key: "calories",
+      title: "Calories",
+      unit: "kcal",
+      value: "N/A",
+    },
+    {
+      key: "steps",
+      title: "Steps",
+      value: "N/A",
+    },
+  ];
+}
+
+function targetLineUnavailable(): CardioTargetLine | null {
+  return { focus: "activeMinutes", value: TARGET_MINUTES, unit: "minutes" };
+}
+
+function snapshotUnavailable(range: TimeRange): CardioProgressSnapshot {
+  const buckets = buildBucketSets(range);
+  const series = SERIES_FOCUSES.reduce<Record<CardioFocus, CardioSeriesResponse>>((acc, focus) => {
+    acc[focus] = seriesUnavailableFromBuckets(focus, buckets);
+    return acc;
+  }, {} as Record<CardioFocus, CardioSeriesResponse>);
+
+  return {
+    range,
+    series,
+    kpis: kpisUnavailable(),
+    workouts: {},
+    targetLine: targetLineUnavailable(),
+  };
+}
+
 class CardioProgressProvider {
-  private cache = new Map<TimeRange, AggregatedData>();
+  private cache = new Map<TimeRange, Promise<AggregatedData>>();
 
   private platformPromise?: Promise<string>;
 
   async snapshot(range: TimeRange): Promise<CardioProgressSnapshot> {
-    logger.debug("[cardio] CardioProgressProvider.snapshot: Called", { range });
-    
+    logger.debug(`${LOG_PREFIX} snapshot`, { range });
+
     try {
       const result = await this.snapshotNative(range);
-      
-      // ADD: Log successful snapshot creation
-      logger.debug("[cardio] CardioProgressProvider.snapshot: Success", {
+      logger.debug(`${LOG_PREFIX} snapshot.success`, {
         range,
-        seriesKeys: Object.keys(result.series || {}),
-        kpiCount: result.kpis?.length || 0,
-        workoutDays: Object.keys(result.workouts || {}).length,
-        workoutCount: Object.values(result.workouts || {}).reduce((total, day) => total + day.length, 0),
-        hasTargetLine: !!result.targetLine
+        kpis: result.kpis?.length ?? 0,
+        workoutDays: Object.keys(result.workouts ?? {}).length,
       });
-
       return result;
     } catch (error) {
-      logger.debug("[cardio] CardioProgressProvider.snapshot: Failed", { range, error });
-      return this.snapshotUnavailable(range);
+      logger.debug(`${LOG_PREFIX} snapshot.failed`, { range, error });
+      return snapshotUnavailable(range);
+    }
+  }
+
+  async series(
+    range: TimeRange,
+    focus: CardioFocus,
+    options?: { compare?: boolean },
+  ): Promise<CardioSeriesResponse> {
+    try {
+      const data = await this.ensure(range);
+      return this.seriesFromAggregated(range, data, focus, options);
+    } catch (error) {
+      logger.debug(`${LOG_PREFIX} series.failed`, { range, focus, error });
+      return seriesUnavailableFromBuckets(focus, buildBucketSets(range), options);
+    }
+  }
+
+  async kpis(range: TimeRange): Promise<CardioKpi[]> {
+    try {
+      const data = await this.ensure(range);
+      return this.kpisFromAggregated(range, data);
+    } catch (error) {
+      logger.debug(`${LOG_PREFIX} kpis.failed`, { range, error });
+      return kpisUnavailable();
+    }
+  }
+
+  async recentWorkouts(range: TimeRange): Promise<CardioWorkoutSummary[]> {
+    try {
+      const data = await this.ensure(range);
+      return this.recentWorkoutsFromAggregated(range, data);
+    } catch (error) {
+      logger.debug(`${LOG_PREFIX} workouts.failed`, { range, error });
+      return [];
+    }
+  }
+
+  async targetLine(range: TimeRange, focus: CardioFocus): Promise<CardioTargetLine | null> {
+    try {
+      return await this.targetLineNative(range, focus);
+    } catch (error) {
+      logger.debug(`${LOG_PREFIX} targetLine.failed`, { range, focus, error });
+      return focus === "activeMinutes" ? targetLineUnavailable() : null;
     }
   }
 
@@ -214,26 +401,10 @@ class CardioProgressProvider {
     options?: { compare?: boolean },
   ): CardioSeriesResponse {
     const selector = METRIC_SELECTORS[focus];
-
-    logger.debug("[cardio] CardioProgressProvider.seriesFromAggregated: Data retrieved", {
-      range,
-      focus,
-      currentBuckets: data.current.length,
-      previousBuckets: data.previous.length,
-      selector: focus,
-    });
+    const includePrevious = options?.compare !== false;
 
     const previousValues = data.previous.map((bucket) => selector(bucket));
     const historicalMax = previousValues.length ? Math.max(...previousValues) : 0;
-    const includePrevious = options?.compare !== false;
-
-    logger.debug("[cardio] CardioProgressProvider.seriesFromAggregated: Historical analysis", {
-      range,
-      focus,
-      previousValues: previousValues.slice(0, 5), // Show first 5 values
-      historicalMax,
-      includePrevious,
-    });
 
     const previous: SeriesPoint[] | undefined = includePrevious && data.previous.length
       ? data.previous.map((bucket) => ({ iso: bucket.iso, value: selector(bucket) }))
@@ -247,42 +418,18 @@ class CardioProgressProvider {
 
     const personalBest = Math.max(historicalMax, ...current.map((point) => point.value));
 
-    logger.debug("[cardio] CardioProgressProvider.seriesFromAggregated: Series calculated", {
+    logger.debug(`${LOG_PREFIX} series`, {
       range,
       focus,
       currentPoints: current.length,
-      previousPoints: previous?.length || 0,
+      previousPoints: previous?.length ?? 0,
       personalBest,
-      currentValues: current.slice(0, 3).map(p => ({ iso: p.iso, value: p.value, isPersonalBest: p.isPersonalBest })) // Show first 3 points
     });
 
     return { focus, current, previous, personalBest: personalBest > 0 ? personalBest : undefined };
   }
 
-
-  private kpisFromAggregated(range: TimeRange, data: AggregatedData): CardioKpi[] {
-    const workoutCount = this.collectWorkouts(data).length;
-
-    // ADD: Log aggregated data totals
-    logger.debug("[cardio] CardioProgressProvider.kpisNative: Aggregated data totals", {
-      range,
-      currentBuckets: data.current.length,
-      previousBuckets: data.previous.length,
-      workoutCount,
-      currentTotals: data.current.reduce((acc, bucket) => ({
-        minutes: acc.minutes + bucket.totals.minutes,
-        distanceKm: acc.distanceKm + bucket.totals.distanceKm,
-        calories: acc.calories + bucket.totals.calories,
-        steps: acc.steps + bucket.totals.steps
-      }), { minutes: 0, distanceKm: 0, calories: 0, steps: 0 }),
-      previousTotals: data.previous.reduce((acc, bucket) => ({
-        minutes: acc.minutes + bucket.totals.minutes,
-        distanceKm: acc.distanceKm + bucket.totals.distanceKm,
-        calories: acc.calories + bucket.totals.calories,
-        steps: acc.steps + bucket.totals.steps
-      }), { minutes: 0, distanceKm: 0, calories: 0, steps: 0 })
-    });
-
+  private kpisFromAggregated(_range: TimeRange, data: AggregatedData): CardioKpi[] {
     const minutesCurrent = data.current.reduce((sum, bucket) => sum + bucket.totals.minutes, 0);
     const minutesPrevious = data.previous.reduce((sum, bucket) => sum + bucket.totals.minutes, 0);
     const distanceCurrent = data.current.reduce((sum, bucket) => sum + bucket.totals.distanceKm, 0);
@@ -294,7 +441,7 @@ class CardioProgressProvider {
 
     const kpis: CardioKpi[] = [
       {
-        key: "activeMinutes" as CardioFocus,
+        key: "activeMinutes",
         title: "Total Time",
         unit: "minutes",
         value: minutesToDisplay(minutesCurrent),
@@ -302,7 +449,7 @@ class CardioProgressProvider {
         previous: minutesPrevious,
       },
       {
-        key: "distance" as CardioFocus,
+        key: "distance",
         title: "Distance",
         unit: "km",
         value: `${kilometersToDisplay(distanceCurrent)} km`,
@@ -310,7 +457,7 @@ class CardioProgressProvider {
         previous: distancePrevious,
       },
       {
-        key: "calories" as CardioFocus,
+        key: "calories",
         title: "Calories",
         unit: "kcal",
         value: `${caloriesToDisplay(caloriesCurrent)} kcal`,
@@ -318,7 +465,7 @@ class CardioProgressProvider {
         previous: caloriesPrevious,
       },
       {
-        key: "steps" as CardioFocus,
+        key: "steps",
         title: "Steps",
         value: `${stepsToDisplay(stepsCurrent)}`,
         currentNumeric: stepsCurrent,
@@ -326,127 +473,63 @@ class CardioProgressProvider {
       },
     ];
 
-    // ADD: Log final KPIs
-    logger.debug("[cardio] CardioProgressProvider.kpisNative: Final KPIs", {
-      range,
-      kpis: kpis.map((kpi: any) => ({
-        key: kpi.key,
-        title: kpi.title,
-        value: kpi.value,
-        currentNumeric: kpi.currentNumeric,
-        previous: kpi.previous
-      }))
+    logger.debug(`${LOG_PREFIX} kpis`, {
+      range: _range,
+      minutesCurrent,
+      distanceCurrent,
+      caloriesCurrent,
+      stepsCurrent,
     });
 
     return kpis;
   }
 
   private recentWorkoutsFromAggregated(range: TimeRange, data: AggregatedData): CardioWorkoutSummary[] {
-    const allWorkouts = this.collectWorkouts(data);
+    const allWorkouts = collectWorkouts(data);
     const currentStart = data.current[0]?.start ?? new Date();
     const currentEnd = data.current[data.current.length - 1]?.end ?? new Date();
 
-    logger.debug("[cardio] CardioProgressProvider.recentWorkoutsNative: Date range", {
-      range,
-      currentStart: currentStart.toISOString(),
-      currentEnd: currentEnd.toISOString(),
-      totalWorkouts: allWorkouts.length
-    });
-
     const filtered = allWorkouts.filter((workout) => {
-      const startDate = new Date(workout.start);
-      return startDate >= currentStart && startDate <= currentEnd;
+      const endDate = new Date(workout.end);
+      return endDate >= currentStart && endDate <= currentEnd;
     });
 
-    logger.debug("[cardio] CardioProgressProvider.recentWorkoutsNative: Filtered workouts", {
-      range,
-      totalWorkouts: allWorkouts.length,
-      filteredCount: filtered.length,
-      sampleWorkouts: filtered.slice(0, 3).map(w => ({
-        id: w.id,
-        activity: w.activity,
-        start: w.start,
-        durationMinutes: w.durationMinutes,
-        distanceKm: w.distanceKm,
-        calories: w.calories
-      }))
-    });
-
-    filtered.sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
+    filtered.sort((a, b) => new Date(b.end).getTime() - new Date(a.end).getTime());
     const result = filtered.slice(0, 6);
 
-    logger.debug("[cardio] CardioProgressProvider.recentWorkoutsNative: Final result", {
+    logger.debug(`${LOG_PREFIX} workouts`, {
       range,
-      resultCount: result.length,
-      workouts: result.map(w => ({
-        id: w.id,
-        activity: w.activity,
-        start: w.start,
-        durationMinutes: w.durationMinutes
-      }))
+      total: allWorkouts.length,
+      returned: result.length,
     });
 
     return result;
   }
 
   private async targetLineNative(_range: TimeRange, focus: CardioFocus): Promise<CardioTargetLine | null> {
-    logger.debug("[cardio] CardioProgressProvider.targetLineNative: Starting", { range: _range, focus });
-    
     if (focus !== "activeMinutes") {
-      logger.debug("[cardio] CardioProgressProvider.targetLineNative: No target line for focus", { focus });
       return null;
     }
-    
-    const result = { focus, value: TARGET_MINUTES, unit: "minutes" };
-    
-    logger.debug("[cardio] CardioProgressProvider.targetLineNative: Target line created", {
-      range: _range,
-      focus,
-      targetLine: result
-    });
-    
-    return result;
+    return { focus, value: TARGET_MINUTES, unit: "minutes" };
   }
 
   private async snapshotNative(range: TimeRange): Promise<CardioProgressSnapshot> {
-    logger.debug("[cardio] CardioProgressProvider.snapshotNative: Starting", { range });
-    
     const data = await this.ensure(range);
 
     const minutesSeries = this.seriesFromAggregated(range, data, "activeMinutes");
     const distanceSeries = this.seriesFromAggregated(range, data, "distance");
     const caloriesSeries = this.seriesFromAggregated(range, data, "calories");
     const stepsSeries = this.seriesFromAggregated(range, data, "steps");
+
     const kpis = this.kpisFromAggregated(range, data);
-    const workouts = this.recentWorkoutsFromAggregated(range, data);
-    const workoutsByDay = this.groupWorkoutsByDate(workouts);
+    const workouts = collectWorkouts(data);
+    const workoutsByDay = groupWorkoutsByDate(workouts);
     const targetLine = await this.targetLineNative(range, "activeMinutes");
 
-    // ADD: Log each component result
-    logger.debug("[cardio] CardioProgressProvider.snapshotNative: Series data", {
+    logger.debug(`${LOG_PREFIX} snapshotNative`, {
       range,
-      activeMinutes: { pointCount: minutesSeries.current?.length || 0, personalBest: minutesSeries.personalBest },
-      distance: { pointCount: distanceSeries.current?.length || 0, personalBest: distanceSeries.personalBest },
-      calories: { pointCount: caloriesSeries.current?.length || 0, personalBest: caloriesSeries.personalBest },
-      steps: { pointCount: stepsSeries.current?.length || 0, personalBest: stepsSeries.personalBest }
-    });
-
-    logger.debug("[cardio] CardioProgressProvider.snapshotNative: KPIs calculated", {
-      range,
-      kpis: kpis.map((kpi: any) => ({
-        key: kpi.key,
-        title: kpi.title,
-        value: kpi.value,
-        currentNumeric: kpi.currentNumeric,
-        previous: kpi.previous
-      }))
-    });
-
-    logger.debug("[cardio] CardioProgressProvider.snapshotNative: Workouts", {
-      range,
-      workoutDays: Object.keys(workoutsByDay).length,
       workoutCount: workouts.length,
-      hasTargetLine: !!targetLine
+      workoutDays: Object.keys(workoutsByDay).length,
     });
 
     return {
@@ -463,133 +546,25 @@ class CardioProgressProvider {
     };
   }
 
-
-  private seriesUnavailableFromBuckets(
-    focus: CardioFocus,
-    buckets: ReturnType<typeof buildBucketSets>,
-    options?: { compare?: boolean },
-  ): CardioSeriesResponse {
-    const includePrevious = options?.compare !== false;
-    const mapBucket = (bucket: Bucket): SeriesPoint => ({ iso: bucket.iso, value: 0 });
-    return {
-      focus,
-      current: buckets.current.map(mapBucket),
-      previous: includePrevious ? buckets.previous.map(mapBucket) : undefined,
-    };
-  }
-
-  private kpisUnavailable(_range: TimeRange): CardioKpi[] {
-    return [
-      {
-        key: "activeMinutes",
-        title: "Total Time",
-        unit: "minutes",
-        value: "N/A",
-      },
-      {
-        key: "distance",
-        title: "Distance",
-        unit: "km",
-        value: "N/A",
-      },
-      {
-        key: "calories",
-        title: "Calories",
-        unit: "kcal",
-        value: "N/A",
-      },
-      {
-        key: "steps",
-        title: "Steps",
-        value: "N/A",
-      },
-    ];
-  }
-
-  private targetLineUnavailable(focus: CardioFocus): CardioTargetLine | null {
-    if (focus !== "activeMinutes") {
-      return null;
-    }
-    return { focus, value: TARGET_MINUTES, unit: "minutes" };
-  }
-
-  private snapshotUnavailable(range: TimeRange): CardioProgressSnapshot {
-    const buckets = buildBucketSets(range);
-    return {
-      range,
-      series: {
-        activeMinutes: this.seriesUnavailableFromBuckets("activeMinutes", buckets),
-        distance: this.seriesUnavailableFromBuckets("distance", buckets),
-        calories: this.seriesUnavailableFromBuckets("calories", buckets),
-        steps: this.seriesUnavailableFromBuckets("steps", buckets),
-      },
-      kpis: this.kpisUnavailable(range),
-      workouts: {},
-      targetLine: this.targetLineUnavailable("activeMinutes"),
-    };
-  }
-
-  public getUnavailableSnapshot(range: TimeRange): CardioProgressSnapshot {
-    return this.snapshotUnavailable(range);
-  }
-
-  private collectWorkouts(data: AggregatedData): CardioWorkoutSummary[] {
-    return [...data.previous, ...data.current].flatMap((bucket) => bucket.workouts);
-  }
-
-  private groupWorkoutsByDate(workouts: CardioWorkoutSummary[]): Record<string, CardioWorkoutSummary[]> {
-    const grouped: Record<string, CardioWorkoutSummary[]> = {};
-    for (const workout of workouts) {
-      const start = new Date(workout.start);
-      if (Number.isNaN(start.getTime())) {
-        continue;
-      }
-      const key = start.toISOString().slice(0, 10);
-      if (!grouped[key]) {
-        grouped[key] = [];
-      }
-      grouped[key].push(workout);
-    }
-
-    for (const key of Object.keys(grouped)) {
-      grouped[key].sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
-    }
-
-    return grouped;
-  }
-
   private async ensure(range: TimeRange): Promise<AggregatedData> {
     if (!this.cache.has(range)) {
-      const loadPromise = this.fetchAggregated(range)
-        .then((result) => result)
-        .catch((error) => {
-          this.cache.delete(range);
-          throw error;
-        });
+      const loadPromise = this.fetchAggregated(range).catch((error) => {
+        this.cache.delete(range);
+        throw error;
+      });
       this.cache.set(range, loadPromise);
     }
     return this.cache.get(range)!;
   }
 
   private async fetchAggregated(range: TimeRange): Promise<AggregatedData> {
-    logger.debug("[cardio] CardioProgressProvider.fetchAggregated: Starting", { range });
-    
+    logger.debug(`${LOG_PREFIX} fetchAggregated.start`, { range });
+
     const { current, previous } = buildBucketSets(range);
     const allBuckets = [...previous, ...current];
-    
-    logger.debug("[cardio] CardioProgressProvider.fetchAggregated: Buckets created", {
-      range,
-      currentBucketCount: current.length,
-      previousBucketCount: previous.length,
-      totalBucketCount: allBuckets.length,
-      dateRange: allBuckets.length > 0 ? {
-        start: allBuckets[0].start.toISOString(),
-        end: allBuckets[allBuckets.length - 1].end.toISOString()
-      } : null
-    });
 
     if (allBuckets.length === 0) {
-      logger.debug("[cardio] CardioProgressProvider.fetchAggregated: No buckets, returning empty data", { range });
+      logger.debug(`${LOG_PREFIX} fetchAggregated.noBuckets`, { range });
       return { range, current, previous };
     }
 
@@ -597,11 +572,11 @@ class CardioProgressProvider {
     const latest = allBuckets[allBuckets.length - 1].end;
 
     const platform = await this.getPlatform();
-
-    logger.debug("[cardio] CardioProgressProvider.fetchAggregated: Platform detected", {
+    logger.debug(`${LOG_PREFIX} fetchAggregated.platform`, {
       range,
       platform,
-      dateRange: { start: earliest.toISOString(), end: latest.toISOString() }
+      start: earliest.toISOString(),
+      end: latest.toISOString(),
     });
 
     if (platform === "ios") {
@@ -609,24 +584,13 @@ class CardioProgressProvider {
     } else if (platform === "android") {
       await this.populateFromAndroid(allBuckets, earliest, latest);
     } else {
-      throw new Error(`Unsupported platform for cardio provider: ${platform}`);
+      logger.warn(`${LOG_PREFIX} fetchAggregated.unsupportedPlatform`, { platform });
     }
 
-    // ADD: Log final aggregated data
-    logger.debug("[cardio] CardioProgressProvider.fetchAggregated: Data populated", {
+    logger.debug(`${LOG_PREFIX} fetchAggregated.complete`, {
       range,
       platform,
       workoutCount: allBuckets.reduce((sum, bucket) => sum + bucket.workouts.length, 0),
-      currentBucketTotals: current.map(bucket => ({
-        iso: bucket.iso,
-        totals: bucket.totals,
-        workouts: bucket.workouts.length
-      })),
-      previousBucketTotals: previous.map(bucket => ({
-        iso: bucket.iso,
-        totals: bucket.totals,
-        workouts: bucket.workouts.length
-      }))
     });
 
     return { range, current, previous };
@@ -639,7 +603,7 @@ class CardioProgressProvider {
           const { Capacitor } = await import("@capacitor/core");
           return Capacitor.getPlatform();
         } catch (error) {
-          logger.debug("[cardio] Unable to resolve platform, defaulting to web", error);
+          logger.debug(`${LOG_PREFIX} platform.webFallback`, { error });
           return "web";
         }
       })();
@@ -649,18 +613,21 @@ class CardioProgressProvider {
 
   private async populateFromIos(
     buckets: Bucket[],
-    startRaw: Date,
-    endRaw: Date,
+    startLocal: Date,
+    endLocal: Date,
   ): Promise<void> {
     try {
       const { Health } = await import("capacitor-health");
-      const start = startRaw.toISOString();
-      const end = endRaw.toISOString();
-      // ADD: Enhanced permission request logging
-      logger.debug("[cardio] iOS populateFromIos: Starting", { start, end, bucketCount: buckets.length, dateRange: `${start} to ${end}`});
-      logger.debug("[cardio] iOS request permissions", { start, end});
+      const startUtc = toUtcISOString(startLocal);
+      const endUtc = toUtcISOString(endLocal);
 
-      const permissionResult = await Health.requestHealthPermissions({
+      logger.debug(`${LOG_PREFIX} ios.populate.start`, {
+        start: startUtc,
+        end: endUtc,
+        bucketCount: buckets.length,
+      });
+
+      await Health.requestHealthPermissions({
         permissions: [
           "READ_WORKOUTS",
           "READ_ACTIVE_CALORIES",
@@ -670,87 +637,63 @@ class CardioProgressProvider {
           "READ_STEPS",
         ],
       });
-      
-      logger.debug("[cardio] iOS permissions result", {  permissions: permissionResult, granted: Object.values(permissionResult).every(Boolean)});
 
-      // ADD: Enhanced workout query logging
-      logger.debug("[cardio] iOS queryWorkouts: Request", {start, end, includeHeartRate: true, includeRoute: false, includeSteps: true});
-      const workoutResponse: any = await Health.queryWorkouts({ startDate: start, endDate: end, includeHeartRate: true, includeRoute: false, includeSteps: true});
-      
-      // ADD: Basic workout response logging
-      logger.debug("[cardio] iOS queryWorkouts: Response", {
-        hasWorkouts: !!workoutResponse?.workouts,
-        workoutCount: Array.isArray(workoutResponse?.workouts) ? workoutResponse.workouts.length : 0,
-        responseKeys: Object.keys(workoutResponse || {})
+      const workoutResponse: any = await Health.queryWorkouts({
+        startDate: startUtc,
+        endDate: endUtc,
+        includeHeartRate: true,
+        includeRoute: false,
+        includeSteps: true,
       });
-      
-      // ADD: Print all workouts one by one in readable format
-      const workoutSamples: any[] = Array.isArray(workoutResponse?.workouts) ? workoutResponse.workouts : [];
-      logger.debug("[cardio] iOS queryWorkouts: Detailed workout breakdown", { 
-        totalWorkouts: workoutSamples.length 
-      });
-      
-      const printWorkout = (workout: any, i: number) => {
-        logger.debug(`[cardio] iOS Workout #${i + 1}/${workoutSamples.length}`, {
-          id: workout?.id || 'N/A',
-          workoutType: workout?.workoutType || 'N/A',
-          startDate: workout?.startDate || 'N/A',
-          endDate: workout?.endDate || 'N/A',
-          duration: workout?.duration || 'N/A',
-          distance: workout?.distance || 'N/A',
-          calories: workout?.calories || 'N/A',
-          steps: workout?.steps || 'N/A',
-          sourceName: workout?.sourceName || 'N/A',
-          heartRateCount: Array.isArray(workout?.heartRate) ? workout.heartRate.length : 0,
-          heartRateSample: Array.isArray(workout?.heartRate) && workout.heartRate.length > 0 ? {
-            firstBpm: workout.heartRate[0]?.bpm || 'N/A',
-            lastBpm: workout.heartRate[workout.heartRate.length - 1]?.bpm || 'N/A',
-            totalReadings: workout.heartRate.length
-          } : null,
-          allKeys: Object.keys(workout || {})
-        });
-      }
-      
-      logger.debug("[cardio] iOS workouts fetched", { count: workoutSamples.length });
 
       const fallbackCalories = new Map<Bucket, number>();
       const fallbackSteps = new Map<Bucket, number>();
-      const collectedWorkouts: CardioWorkoutSummary[] = [];
 
-      for (let i = 0; i < workoutSamples.length; i++) {
-        printWorkout(workoutSamples[i], i);
+      const workoutSamples: any[] = Array.isArray(workoutResponse?.workouts)
+        ? workoutResponse.workouts
+        : [];
 
-        const sample = workoutSamples[i];
-        const startDate = new Date(sample?.startDate ?? sample?.startTime ?? 0);
-        const endDate = new Date(sample?.endDate ?? sample?.endTime ?? 0);
-        if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) continue;
-        const bucket = findBucket(buckets, startDate);
-        if (!bucket) continue;
+      for (const sample of workoutSamples) {
+        const startDate = toLocalDateTime(sample?.startDate ?? sample?.startTime);
+        const endDate = toLocalDateTime(sample?.endDate ?? sample?.endTime);
+        if (!startDate || !endDate) {
+          continue;
+        }
+
+        const bucket = findBucket(buckets, endDate);
+        if (!bucket) {
+          continue;
+        }
 
         const rawDuration = safeNumber(sample?.duration);
-        const durationMinutes = rawDuration > 0 ? rawDuration / 60 : Math.max(0, (endDate.getTime() - startDate.getTime()) / MIN_MS);
+        const durationMinutes =
+          rawDuration > 0
+            ? rawDuration / 60
+            : Math.max(0, (endDate.getTime() - startDate.getTime()) / MIN_MS);
+
         const distanceMeters = safeNumber(sample?.distance);
         const distanceKm = distanceMeters > 0 ? distanceMeters / 1000 : undefined;
-        const calories = safeNumber(sample?.calories);
+        const calories = safeNumber(sample?.calories ?? sample?.totalEnergyBurned);
         const steps = safeNumber(sample?.steps);
 
         bucket.totals.minutes += durationMinutes;
-        if (distanceKm) bucket.totals.distanceKm += distanceKm;
-        if (calories) {
-          const existing = fallbackCalories.get(bucket) ?? 0;
-          fallbackCalories.set(bucket, existing + calories);
+        if (distanceKm && distanceKm > 0) {
+          bucket.totals.distanceKm += distanceKm;
         }
 
-        if (steps) {
-          const existingSteps = fallbackSteps.get(bucket) ?? 0;
-          fallbackSteps.set(bucket, existingSteps + steps);
+        if (calories > 0) {
+          fallbackCalories.set(bucket, (fallbackCalories.get(bucket) ?? 0) + calories);
+        }
+
+        if (steps > 0) {
+          fallbackSteps.set(bucket, (fallbackSteps.get(bucket) ?? 0) + steps);
         }
 
         let workoutHeartRateSum = 0;
         let workoutHeartRateCount = 0;
         if (Array.isArray(sample?.heartRate)) {
           for (const reading of sample.heartRate) {
-            const bpm = safeNumber(reading?.bpm);
+            const bpm = safeNumber(reading?.bpm ?? reading?.beatsPerMinute);
             if (bpm > 0) {
               bucket.totals.heartRateSum += bpm;
               bucket.totals.heartRateCount += 1;
@@ -761,135 +704,60 @@ class CardioProgressProvider {
         }
 
         const workoutSummary: CardioWorkoutSummary = {
-          id: sample?.id ?? `ios-${startDate.getTime()}`,
-          activity: normalizeActivityName(sample?.workoutType),
+          id: sample?.id ?? `ios-${endDate.getTime()}`,
+          activity: normalizeActivityName(sample?.workoutType ?? sample?.activityName),
           start: startDate.toISOString(),
           end: endDate.toISOString(),
           durationMinutes,
           distanceKm,
-          calories: calories || undefined,
-          steps: steps || undefined,
-          averageHeartRate: workoutHeartRateCount > 0 ? workoutHeartRateSum / workoutHeartRateCount : undefined,
+          calories: calories > 0 ? calories : undefined,
+          steps: steps > 0 ? steps : undefined,
+          averageHeartRate:
+            workoutHeartRateCount > 0
+              ? workoutHeartRateSum / workoutHeartRateCount
+              : undefined,
           source: sample?.sourceName,
         };
-        //logger.debug("[cardio] iOS workout summary", { workoutSummary });
+
         bucket.workouts.push(workoutSummary);
-        collectedWorkouts.push(workoutSummary);
-      }
-      for (const workout of collectedWorkouts) {
-        logger.debug("🔍 DGB [CARDIO_PROGRESS] Workout:", JSON.stringify(workout, null, 2));
-      }
-      try {
-        // ADD: Enhanced steps aggregation logging
-        logger.debug("[cardio] iOS queryAggregated steps: Request", { start, end, dataType: "steps", bucket: "day"});
-        
-        const stepsAggregated: any = await Health.queryAggregated({startDate: start, endDate: end, dataType: "steps", bucket: "day"});
-        
-        // ADD: Enhanced steps response logging
-        logger.debug("[cardio] iOS queryAggregated steps: Response", {
-          hasAggregatedData: !!stepsAggregated?.aggregatedData,
-          dataCount: Array.isArray(stepsAggregated?.aggregatedData) ? stepsAggregated.aggregatedData.length : 0,
-          responseKeys: Object.keys(stepsAggregated || {}),
-          sampleData: Array.isArray(stepsAggregated?.aggregatedData) && stepsAggregated.aggregatedData.length > 0 ? {
-            startDate: stepsAggregated.aggregatedData[0]?.startDate,
-            date: stepsAggregated.aggregatedData[0]?.date,
-            value: stepsAggregated.aggregatedData[0]?.value
-          } : null
-        });
-        
-        const stepRows: any[] = Array.isArray(stepsAggregated?.aggregatedData) ? stepsAggregated.aggregatedData : [];
-        let processedSteps = 0;
-        let totalSteps = 0;
-        
-        // ADD: Print all step data one by one in readable format
-        logger.debug("[cardio] iOS queryAggregated steps: Detailed step breakdown", { totalStepRows: stepRows.length });
-        
-        const printStep = (row: any, i: number) => {
-          logger.debug(`[cardio] iOS Step Row #${i + 1}/${stepRows.length}`, {
-            startDate: row?.startDate || 'N/A',
-            date: row?.date || 'N/A',
-            value: row?.value || 'N/A',
-            allKeys: Object.keys(row || {})
-          });
-        }
-        
-        for (let i = 0; i < stepRows.length; i++) {
-          const row = stepRows[i];
-          printStep(row, i);
-          const rowDate = new Date(row?.startDate ?? row?.date ?? 0);
-          const bucket = findBucket(buckets, rowDate);
-          if (!bucket) continue;
-          const stepValue = safeNumber(row?.value);
-          bucket.totals.steps += stepValue;
-          totalSteps += stepValue;
-          processedSteps++;
-        }
-        
-        logger.debug("[cardio] iOS steps processed", {
-          processedRows: processedSteps,
-          totalSteps,
-          bucketsWithSteps: buckets.filter(b => b.totals.steps > 0).length
-        });
-      } catch (error) {
-        logger.debug("[cardio] iOS step aggregation failed", error);
       }
 
-      try {
-        // ADD: Enhanced calories aggregation logging
-        logger.debug("[cardio] iOS queryAggregated active calories: Request", { start, end, dataType: "active-calories", bucket: "day"});
-        
-        const caloriesAggregated: any = await Health.queryAggregated({startDate: start, endDate: end, dataType: "active-calories", bucket: "day"});
-        
-        // ADD: Enhanced calories response logging
-        logger.debug("[cardio] iOS queryAggregated active calories: Response", {
-          hasAggregatedData: !!caloriesAggregated?.aggregatedData,
-          dataCount: Array.isArray(caloriesAggregated?.aggregatedData) ? caloriesAggregated.aggregatedData.length : 0,
-          responseKeys: Object.keys(caloriesAggregated || {}),
-          sampleData: Array.isArray(caloriesAggregated?.aggregatedData) && caloriesAggregated.aggregatedData.length > 0 ? {
-            startDate: caloriesAggregated.aggregatedData[0]?.startDate,
-            date: caloriesAggregated.aggregatedData[0]?.date,
-            value: caloriesAggregated.aggregatedData[0]?.value
-          } : null
+      const applyAggregated = async (
+        dataType: string,
+        apply: (bucket: Bucket, value: number) => void,
+      ) => {
+        const response: any = await Health.queryAggregated({
+          startDate: startUtc,
+          endDate: endUtc,
+          dataType,
+          bucket: "day",
         });
-        
-        const calorieRows: any[] = Array.isArray(caloriesAggregated?.aggregatedData) ? caloriesAggregated.aggregatedData : [];
-        let processedCalories = 0;
-        let totalCalories = 0;
-        
-        // ADD: Print all calorie data one by one in readable format
-        logger.debug("[cardio] iOS queryAggregated calories: Detailed calorie breakdown", { totalCalorieRows: calorieRows.length });
-        
-        const printCalorie = (row: any, i: number) => {
-          logger.debug(`[cardio] iOS Calorie Row #${i + 1}/${calorieRows.length}`, {
-            startDate: row?.startDate || 'N/A',
-            date: row?.date || 'N/A',
-            value: row?.value || 'N/A',
-            allKeys: Object.keys(row || {})
-          });
-        }
-        
-        for (let i = 0; i < calorieRows.length; i++) {
-          const row = calorieRows[i];
-          printCalorie(row, i);
-          const rowDate = new Date(row?.startDate ?? row?.date ?? 0);
+
+        const rows: any[] = Array.isArray(response?.aggregatedData)
+          ? response.aggregatedData
+          : [];
+
+        for (const row of rows) {
+          const rowDate = toLocalDate(row?.startDate ?? row?.date);
+          if (!rowDate) continue;
+
           const bucket = findBucket(buckets, rowDate);
           if (!bucket) continue;
+
           const value = safeNumber(row?.value);
           if (value > 0) {
-            bucket.totals.calories += value;
-            totalCalories += value;
-            processedCalories++;
+            apply(bucket, value);
           }
         }
-        
-        logger.debug("[cardio] iOS calories processed", {
-          processedRows: processedCalories, 
-          totalCalories,
-          bucketsWithCalories: buckets.filter(b => b.totals.calories > 0).length});
+      };
 
-      } catch (error) {
-        logger.debug("[cardio] iOS calorie aggregation failed", error);
-      }
+      await applyAggregated("steps", (bucket, value) => {
+        bucket.totals.steps += value;
+      });
+
+      await applyAggregated("active-calories", (bucket, value) => {
+        bucket.totals.calories += value;
+      });
 
       for (const bucket of buckets) {
         if (bucket.totals.calories <= 0 && fallbackCalories.has(bucket)) {
@@ -899,50 +767,44 @@ class CardioProgressProvider {
           bucket.totals.steps = fallbackSteps.get(bucket) ?? 0;
         }
       }
-      
-      // ADD: Final summary logging
-      logger.debug("[cardio] iOS populateFromIos: Final summary", {
-        totalWorkouts: collectedWorkouts.length,
-        totalBuckets: buckets.length,
-        bucketsWithData: buckets.filter(b =>
-          b.totals.minutes > 0 ||
-          b.totals.distanceKm > 0 ||
-          b.totals.calories > 0 ||
-          b.totals.steps > 0
-        ).length,
-        totalMinutes: buckets.reduce((sum, b) => sum + b.totals.minutes, 0),
-        totalDistance: buckets.reduce((sum, b) => sum + b.totals.distanceKm, 0),
-        totalCalories: buckets.reduce((sum, b) => sum + b.totals.calories, 0),
-        totalSteps: buckets.reduce((sum, b) => sum + b.totals.steps, 0),
-        fallbackCaloriesUsed: fallbackCalories.size,
-        fallbackStepsUsed: fallbackSteps.size
+
+      logger.debug(`${LOG_PREFIX} ios.populate.complete`, {
+        workouts: workoutSamples.length,
+        bucketsWithWorkouts: buckets.filter((bucket) => bucket.workouts.length > 0).length,
       });
     } catch (error) {
-      logger.warn("[cardio] Failed to populate iOS cardio data", error);
+      logger.warn(`${LOG_PREFIX} ios.populate.error`, { error });
       throw error;
     }
   }
 
   private async populateFromAndroid(
     buckets: Bucket[],
-    start: Date,
-    end: Date,
+    startLocal: Date,
+    endLocal: Date,
   ): Promise<void> {
     try {
       const { HealthConnect } = await import("@kiwi-health/capacitor-health-connect");
-      logger.debug("[cardio] Android request permissions", { start: start.toISOString(), end: end.toISOString() });
+      const startUtc = toUtcDate(startLocal);
+      const endUtc = toUtcDate(endLocal);
+
+      logger.debug(`${LOG_PREFIX} android.populate.start`, {
+        start: startUtc.toISOString(),
+        end: endUtc.toISOString(),
+        bucketCount: buckets.length,
+      });
+
       await HealthConnect.requestHealthPermissions({
         read: ["Steps", "Distance", "ActiveCaloriesBurned", "HeartRateSeries"],
         write: [],
       });
 
-      const timeRangeFilter = { type: "between", startTime: start, endTime: end } as const;
+      const timeRangeFilter = { type: "between", startTime: startUtc, endTime: endUtc } as const;
 
       const readAllRecords = async (type: string) => {
         const records: any[] = [];
         let pageToken: string | undefined;
         do {
-          logger.debug("[cardio] Android readRecords", { type, pageToken });
           const response: any = await HealthConnect.readRecords({
             type: type as any,
             timeRangeFilter,
@@ -959,20 +821,26 @@ class CardioProgressProvider {
 
       const stepRecords = await readAllRecords("Steps");
       for (const record of stepRecords) {
-        const startDate = new Date(record?.startTime ?? 0);
-        const bucket = findBucket(buckets, startDate);
+        const bucketDate = toLocalDate(record?.endTime ?? record?.startTime);
+        if (!bucketDate) continue;
+        const bucket = findBucket(buckets, bucketDate);
         if (!bucket) continue;
-        bucket.totals.steps += safeNumber(record?.count);
+
+        const steps = safeNumber(record?.count);
+        if (steps > 0) {
+          bucket.totals.steps += steps;
+        }
       }
 
       const distanceRecords = await readAllRecords("Distance");
-      const collectedWorkouts: CardioWorkoutSummary[] = [];
       for (const record of distanceRecords) {
-        const startDate = new Date(record?.startTime ?? 0);
-        const endDate = new Date(record?.endTime ?? 0);
-        if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) continue;
-        const bucket = findBucket(buckets, startDate);
+        const startDate = toLocalDateTime(record?.startTime);
+        const endDate = toLocalDateTime(record?.endTime);
+        if (!startDate || !endDate) continue;
+
+        const bucket = findBucket(buckets, endDate);
         if (!bucket) continue;
+
         const durationMinutes = Math.max(0, (endDate.getTime() - startDate.getTime()) / MIN_MS);
         const distanceValue = safeNumber(record?.distance?.value);
         const unit = (record?.distance?.unit ?? "meter").toLowerCase();
@@ -984,11 +852,14 @@ class CardioProgressProvider {
         } else if (unit === "mile") {
           distanceKm = distanceValue * 1.60934;
         }
-        if (distanceKm) bucket.totals.distanceKm += distanceKm;
+
         bucket.totals.minutes += durationMinutes;
+        if (distanceKm && distanceKm > 0) {
+          bucket.totals.distanceKm += distanceKm;
+        }
 
         const workoutSummary: CardioWorkoutSummary = {
-          id: record?.metadata?.id ?? `android-distance-${startDate.getTime()}`,
+          id: record?.metadata?.id ?? `android-distance-${endDate.getTime()}`,
           activity: normalizeActivityName("Distance"),
           start: startDate.toISOString(),
           end: endDate.toISOString(),
@@ -996,15 +867,17 @@ class CardioProgressProvider {
           distanceKm,
           source: record?.metadata?.dataOrigin,
         };
+
         bucket.workouts.push(workoutSummary);
-        collectedWorkouts.push(workoutSummary);
       }
 
       const calorieRecords = await readAllRecords("ActiveCaloriesBurned");
       for (const record of calorieRecords) {
-        const startDate = new Date(record?.startTime ?? 0);
-        const bucket = findBucket(buckets, startDate);
+        const bucketDate = toLocalDate(record?.endTime ?? record?.startTime);
+        if (!bucketDate) continue;
+        const bucket = findBucket(buckets, bucketDate);
         if (!bucket) continue;
+
         const energy = safeNumber(record?.energy?.value);
         if (energy > 0) {
           bucket.totals.calories += energy;
@@ -1013,9 +886,11 @@ class CardioProgressProvider {
 
       const heartRateRecords = await readAllRecords("HeartRateSeries");
       for (const record of heartRateRecords) {
-        const startDate = new Date(record?.startTime ?? 0);
-        const bucket = findBucket(buckets, startDate);
+        const bucketDate = toLocalDate(record?.endTime ?? record?.startTime);
+        if (!bucketDate) continue;
+        const bucket = findBucket(buckets, bucketDate);
         if (!bucket) continue;
+
         if (Array.isArray(record?.samples)) {
           for (const sample of record.samples) {
             const bpm = safeNumber(sample?.beatsPerMinute);
@@ -1026,24 +901,28 @@ class CardioProgressProvider {
           }
         }
       }
-      logger.debug("[cardio] Android populateFromAndroid: Final summary", {
-        totalWorkouts: collectedWorkouts.length,
-        totalBuckets: buckets.length,
-        bucketsWithData: buckets.filter(b =>
-          b.totals.minutes > 0 ||
-          b.totals.distanceKm > 0 ||
-          b.totals.calories > 0 ||
-          b.totals.steps > 0
-        ).length,
-        totalMinutes: buckets.reduce((sum, b) => sum + b.totals.minutes, 0),
-        totalDistance: buckets.reduce((sum, b) => sum + b.totals.distanceKm, 0),
-        totalCalories: buckets.reduce((sum, b) => sum + b.totals.calories, 0),
-        totalSteps: buckets.reduce((sum, b) => sum + b.totals.steps, 0)
+
+      for (const bucket of buckets) {
+        const avg = averageHeartRate(bucket);
+        if (avg !== undefined) {
+          bucket.workouts = bucket.workouts.map((workout) =>
+            workout.averageHeartRate ? workout : { ...workout, averageHeartRate: avg },
+          );
+        }
+      }
+
+      logger.debug(`${LOG_PREFIX} android.populate.complete`, {
+        workouts: buckets.reduce((total, bucket) => total + bucket.workouts.length, 0),
+        bucketsWithWorkouts: buckets.filter((bucket) => bucket.workouts.length > 0).length,
       });
     } catch (error) {
-      logger.warn("[cardio] Failed to populate Android cardio data", error);
+      logger.warn(`${LOG_PREFIX} android.populate.error`, { error });
       throw error;
     }
+  }
+
+  public getUnavailableSnapshot(range: TimeRange): CardioProgressSnapshot {
+    return snapshotUnavailable(range);
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify CardioProgress by centralizing fallback snapshot helpers and lightweight logging
- convert native workout samples back to local time, bucket by local end date, and fetch native data with UTC windows on both iOS and Android
- trim unused logic while ensuring workouts and KPI totals derive from the cleaned bucket data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6822268cc8321944bdefee08d1128