### PR TITLE
Enable cardio week selection for empty days

### DIFF
--- a/components/screens/progress/CardioWeekHistory.tsx
+++ b/components/screens/progress/CardioWeekHistory.tsx
@@ -52,7 +52,6 @@ export type CardioWeekHistoryDay = {
     steps?: ReactNode;
   };
   workouts: CardioWeekHistoryWorkout[];
-  historyEntries: CardioWorkoutSummary[];
 };
 
 type StyleWithRing = CSSProperties & { ["--tw-ring-color"]?: string };
@@ -216,7 +215,6 @@ export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSumma
       {
         date: Date;
         workouts: CardioWeekHistoryDay["workouts"];
-        historyEntries: CardioWorkoutSummary[];
         totals: AggregatedTotals;
         label?: string;
       }
@@ -245,7 +243,6 @@ export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSumma
       acc.set(key, {
         date,
         workouts: [],
-        historyEntries: [],
         totals: {},
         label: getWeekdayLabel(date),
       });
@@ -255,7 +252,6 @@ export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSumma
     const sorted = [...workouts].sort((a, b) => new Date(b.start).getTime() - new Date(a.start).getTime());
 
     for (const workout of sorted) {
-      group.historyEntries.push(workout);
       group.workouts.push({
         id: workout.id,
         type: "cardio",
@@ -291,7 +287,7 @@ export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSumma
 
   const result = Array.from(grouped.values())
     .sort((a, b) => b.date.getTime() - a.date.getTime())
-    .map(({ date, workouts, historyEntries, totals, label }) => {
+    .map(({ date, workouts, totals, label }) => {
       const weekIndex = getWeekIndex(date);
       const formattedTotals: CardioWeekHistoryDay["dailyTotals"] = {
         calories: typeof totals.calories === "number" ? Math.round(totals.calories) : totals.calories,
@@ -307,7 +303,6 @@ export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSumma
         dateLabel: formatDateLabel(date),
         dailyTotals: formattedTotals,
         workouts,
-        historyEntries,
       } satisfies CardioWeekHistoryDay;
     });
 
@@ -331,7 +326,6 @@ export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSumma
       dateLabel: formatDateLabel(date),
       dailyTotals: {},
       workouts: [],
-      historyEntries: [],
     };
 
     result.push(placeholder);

--- a/components/screens/progress/CardioWeekHistory.tsx
+++ b/components/screens/progress/CardioWeekHistory.tsx
@@ -158,47 +158,13 @@ class Workout {
     if (typeof value === "number") {
       return value.toLocaleString();
     }
-    return value ?? "—";
+    return value ?? "N/A";
   }
 
-  get metricTwo() {
-    if (this.isStrength) {
-      if (this.exercises !== undefined) {
-        return { label: "Exercises", value: this.formatMetric(this.exercises) };
-      }
-      if (this.rounds !== undefined) {
-        return { label: "Rounds", value: this.formatMetric(this.rounds) };
-      }
-    }
-    if (this.distance !== undefined) {
-      return { label: "Distance", value: this.formatMetric(this.distance) };
-    }
-    if (this.volume !== undefined) {
-      return { label: "Volume", value: this.formatMetric(this.volume) };
-    }
-    if (this.rounds !== undefined) {
-      return { label: "Rounds", value: this.formatMetric(this.rounds) };
-    }
-    return { label: this.isStrength ? "Exercises" : "Distance", value: "—" };
-  }
-
-  get metricThree() {
-    if (this.isStrength) {
-      if (this.sets !== undefined) {
-        return { label: "Sets", value: this.formatMetric(this.sets) };
-      }
-      if (this.rounds !== undefined && this.metricTwo.label !== "Rounds") {
-        return { label: "Rounds", value: this.formatMetric(this.rounds) };
-      }
-    }
-    if (this.steps !== undefined) {
-      return { label: "Steps", value: this.formatMetric(this.steps) };
-    }
-    if (this.rounds !== undefined && this.metricTwo.label !== "Rounds") {
-      return { label: "Rounds", value: this.formatMetric(this.rounds) };
-    }
-    return { label: this.isStrength ? "Sets" : "Steps", value: "—" };
-  }
+  get metricOne() { return { label: "Duration", value: this.formatMetric(this.duration) };}
+  get metricTwo() { return { label: "Distance", value: this.formatMetric(this.distance)};}
+  get metricThree() {return { label: "Steps", value: this.formatMetric(this.steps)};}
+  get metricFour() { return { label: "Calories", value: this.formatMetric(this.calories)};}
 }
 
 export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSummary[]>): CardioWeekHistoryDay[] {
@@ -505,11 +471,11 @@ function DailyWorkoutCard({ days, dayKey, setDayKey }: DailyWorkoutCardProps) {
   }
 
   const totals = [
-    { Icon: Flame, label: "Calories", value: day.dailyTotals.calories },
-    { Icon: Clock, label: "Duration", value: day.dailyTotals.time },
-    { Icon: MapPin, label: "Distance", value: day.dailyTotals.distance },
-    { Icon: Footprints, label: "Steps", value: day.dailyTotals.steps },
-  ].filter((item) => item.value !== undefined && item.value !== null);
+    { Icon: Flame, label: "Calories", value: day.dailyTotals.calories ?? "N/A" },
+    { Icon: Clock, label: "Duration", value: day.dailyTotals.time ?? "N/A" },
+    { Icon: MapPin, label: "Distance", value: day.dailyTotals.distance ?? "N/A" },
+    { Icon: Footprints, label: "Steps", value: day.dailyTotals.steps ?? "N/A" },
+  ];
 
   return (
     <section className="w-full rounded-3xl border bg-white p-5" style={SECTION_STYLE}>
@@ -526,7 +492,7 @@ function DailyWorkoutCard({ days, dayKey, setDayKey }: DailyWorkoutCardProps) {
               <div key={label} className="flex items-center gap-2">
                 <Icon className="h-3 w-3" style={{ color: PROGRESS_THEME.textMuted }} />
                 <div className="flex flex-col">
-                  <span className="text-xs font-semibold" style={{ color: PROGRESS_THEME.textPrimary }}>
+                  <span className="text-xs font-semibold text-center" style={{ color: PROGRESS_THEME.textPrimary }}>
                     {typeof value === "number" ? value.toLocaleString() : value}
                   </span>
                   <span className="text-xs uppercase tracking-[0.01em]" style={{ color: PROGRESS_THEME.textMuted }}>
@@ -618,7 +584,7 @@ function DailyWorkoutCard({ days, dayKey, setDayKey }: DailyWorkoutCardProps) {
 
                       <div className="flex text-center" style={{ gap: "clamp(0.25rem, 2vw, 1rem)" }}>
                         <div className="flex-1">
-                          <Metric value={workout.duration ?? "—"} label="Duration" align="center" />
+                          <Metric value={workout.metricOne.value} label={workout.metricOne.label} align="center" />
                         </div>
                         <div className="flex-1">
                           <Metric value={workout.metricTwo.value} label={workout.metricTwo.label} align="center" />
@@ -627,7 +593,7 @@ function DailyWorkoutCard({ days, dayKey, setDayKey }: DailyWorkoutCardProps) {
                           <Metric value={workout.metricThree.value} label={workout.metricThree.label} align="center" />
                         </div>
                         <div className="flex-1">
-                          <Metric value={workout.calories ?? "—"} label="Calories" align="center" />
+                          <Metric value={workout.metricFour.value} label={workout.metricFour.label} align="center" />
                         </div>
                       </div>
                     </div>

--- a/components/screens/progress/CardioWeekHistory.tsx
+++ b/components/screens/progress/CardioWeekHistory.tsx
@@ -27,6 +27,7 @@ const cn = (...classes: Array<string | false | null | undefined>) => classes.fil
 export type CardioWeekHistoryWorkout = {
   id: number | string;
   name: string;
+  source?: string;
   duration?: ReactNode;
   time?: string;
   calories?: ReactNode;
@@ -106,6 +107,7 @@ class Workout {
   id: number | string;
   type: string;
   name: string;
+  source?: string;
   duration?: ReactNode;
   time?: string;
   calories?: ReactNode;
@@ -122,6 +124,7 @@ class Workout {
     this.id = data.id;
     this.type = data.type ?? "cardio";
     this.name = data.name;
+    this.source = data.source;
     this.duration = data.duration;
     this.time = data.time;
     this.calories = data.calories;
@@ -256,6 +259,7 @@ export function buildCardioWeekHistory(groups: Record<string, CardioWorkoutSumma
         id: workout.id,
         type: "cardio",
         name: workout.activity,
+        source: workout.source,
         duration: formatHistoryDuration(workout.durationMinutes),
         distance:
           typeof workout.distanceKm === "number"
@@ -586,6 +590,14 @@ function DailyWorkoutCard({ days, dayKey, setDayKey }: DailyWorkoutCardProps) {
                             <h5 className="text-sm font-semibold" style={{ color: PROGRESS_THEME.textPrimary }}>
                               {workout.name}
                             </h5>
+                            {workout.source ? (
+                              <span
+                                className="text-xs font-medium"
+                                style={{ color: PROGRESS_THEME.textMuted }}
+                              >
+                                • {workout.source}
+                              </span>
+                            ) : null}
                             {workout.personalRecords ? (
                               <span
                                 className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium"


### PR DESCRIPTION
## Summary
- add placeholder cardio history entries for completed days so the week strip stays interactive even without data
- surface a notice inside the daily workout card when no workouts are available for the selected day

## Testing
- npm test *(fails: SyntaxError: Cannot use 'import.meta' outside a module in utils/supabase/supabase-db-write.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d69eeb99608321906cf48d540c4d72