### PR TITLE
Restyle progress range selector

### DIFF
--- a/components/screens/progress/RangeSelector.tsx
+++ b/components/screens/progress/RangeSelector.tsx
@@ -4,14 +4,27 @@ import type { TimeRange } from "@/types/progress";
 import { PROGRESS_THEME } from "./util";
 import { RANGE_OPTIONS, type RangeOption } from "./constants";
 
+const RANGE_GROUP_STYLE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 8,
+  padding: 4,
+  borderRadius: 9999,
+  backgroundColor: PROGRESS_THEME.cardBackground,
+  border: `1px solid ${PROGRESS_THEME.borderSubtle}`,
+  boxShadow: PROGRESS_THEME.rangeButtonShadow,
+};
+
 const RANGE_BUTTON_STYLE = (isActive: boolean): CSSProperties => ({
-  backgroundColor: isActive ? PROGRESS_THEME.accentSecondary : "transparent",
-  color: isActive ? "#ffffff" : PROGRESS_THEME.accentSecondary,
-  border: `1px solid ${PROGRESS_THEME.accentSecondary}`,
-  boxShadow: isActive ? PROGRESS_THEME.rangeButtonShadowActive : PROGRESS_THEME.rangeButtonShadow,
-  transform: isActive ? "scale(1.05)" : "scale(1)",
-  transition: "all 0.28s cubic-bezier(0.22, 0.61, 0.36, 1)",
-  minWidth: 86,
+  backgroundColor: isActive ? PROGRESS_THEME.accentPrimary : "#FFFFFF",
+  color: isActive ? "#FFFFFF" : PROGRESS_THEME.textPrimary,
+  borderRadius: 9999,
+  border: "none",
+  boxShadow: isActive ? PROGRESS_THEME.rangeButtonShadowActive : "none",
+  transform: isActive ? "translateY(-1px)" : "translateY(0)",
+  transition: "all 0.24s cubic-bezier(0.4, 0, 0.2, 1)",
+  minWidth: 60,
+  padding: "8px 18px",
 });
 
 interface RangeSelectorProps {
@@ -22,22 +35,25 @@ interface RangeSelectorProps {
 
 export function RangeSelector({ range, onChange, options = RANGE_OPTIONS }: RangeSelectorProps) {
   return (
-    <section className="flex flex-wrap items-center justify-center gap-2 px-1 py-1">
-      {options.map((option) => {
-        const isActive = option.value === range;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            onClick={() => onChange(option.value)}
-            aria-pressed={isActive}
-            className="rounded-full px-4 py-2 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[rgba(30,36,50,0.2)] sm:text-sm"
-            style={RANGE_BUTTON_STYLE(isActive)}
-          >
-            {option.label}
-          </button>
-        );
-      })}
+    <section className="flex w-full justify-end px-1 py-1">
+      <div style={RANGE_GROUP_STYLE}>
+        {options.map((option) => {
+          const isActive = option.value === range;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onChange(option.value)}
+              aria-pressed={isActive}
+              className="rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[rgba(226,125,96,0.35)]"
+              style={RANGE_BUTTON_STYLE(isActive)}
+              data-testid={`progress-range-${option.value}`}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
     </section>
   );
 }

--- a/components/screens/progress/RangeSelector.tsx
+++ b/components/screens/progress/RangeSelector.tsx
@@ -9,7 +9,7 @@ const RANGE_GROUP_STYLE: CSSProperties = {
   alignItems: "center",
   gap: 8,
   padding: 4,
-  borderRadius: 9999,
+  borderRadius: 1000,
   backgroundColor: PROGRESS_THEME.cardBackground,
   border: `1px solid ${PROGRESS_THEME.borderSubtle}`,
   boxShadow: PROGRESS_THEME.rangeButtonShadow,
@@ -18,13 +18,13 @@ const RANGE_GROUP_STYLE: CSSProperties = {
 const RANGE_BUTTON_STYLE = (isActive: boolean): CSSProperties => ({
   backgroundColor: isActive ? PROGRESS_THEME.accentPrimary : "#FFFFFF",
   color: isActive ? "#FFFFFF" : PROGRESS_THEME.textPrimary,
-  borderRadius: 9999,
+  borderRadius: 1000,
   border: "none",
   boxShadow: isActive ? PROGRESS_THEME.rangeButtonShadowActive : "none",
   transform: isActive ? "translateY(-1px)" : "translateY(0)",
   transition: "all 0.24s cubic-bezier(0.4, 0, 0.2, 1)",
-  minWidth: 60,
-  padding: "8px 18px",
+  minWidth: 40,
+  padding: "6px 12px",
 });
 
 interface RangeSelectorProps {
@@ -45,7 +45,7 @@ export function RangeSelector({ range, onChange, options = RANGE_OPTIONS }: Rang
               type="button"
               onClick={() => onChange(option.value)}
               aria-pressed={isActive}
-              className="rounded-full px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[rgba(226,125,96,0.35)]"
+              className="px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[rgba(226,125,96,0.35)]"
               style={RANGE_BUTTON_STYLE(isActive)}
               data-testid={`progress-range-${option.value}`}
             >

--- a/components/screens/progress/constants.ts
+++ b/components/screens/progress/constants.ts
@@ -10,9 +10,9 @@ export const DOMAIN_OPTIONS: DomainOption[] = [
 ];
 
 export const RANGE_OPTIONS: RangeOption[] = [
-  { value: "week", label: "Week" },
-  { value: "threeMonths", label: "3 Month" },
-  { value: "sixMonths", label: "6 Month" },
+  { value: "week", label: "W" },
+  { value: "threeMonths", label: "3M" },
+  { value: "sixMonths", label: "6M" },
 ];
 
 export const DOMAIN_LABELS: Record<ProgressDomain, string> = {
@@ -21,7 +21,7 @@ export const DOMAIN_LABELS: Record<ProgressDomain, string> = {
 };
 
 export const RANGE_LABELS: Record<TimeRange, string> = {
-  week: "Week",
-  threeMonths: "3 Month",
-  sixMonths: "6 Month",
+  week: "W",
+  threeMonths: "3M",
+  sixMonths: "6M",
 };


### PR DESCRIPTION
## Summary
- restyle the progress range selector as a right-aligned pill control that matches the app theme
- change the range labels to W, 3M, and 6M so the filter matches the requested mockup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6d7eb0bb083218db23ed6d23e89f6